### PR TITLE
Fix bouncy button transparent ripple

### DIFF
--- a/components/BouncyButton.tsx
+++ b/components/BouncyButton.tsx
@@ -125,7 +125,7 @@ export function BouncyButton({
         enableRipple
           ? {
               overflow: 'hidden',
-              backgroundColor: 'rgba(0,0,0,0.01)',
+              backgroundColor: 'transparent',
               borderRadius,
             }
           : undefined,


### PR DESCRIPTION
Replaces the slightly opaque black background color used for the Android ripple clipping with 'transparent' in BouncyButton. This fixes an issue where an unintended shadow artifact was visible, while still allowing the border radius clipping to function properly.

---
*PR created automatically by Jules for task [4544493350437006264](https://jules.google.com/task/4544493350437006264) started by @huamurui*