### PR TITLE
fix(ios): expand dark mode textSecondary short hex #bbb to #bbbbbb

### DIFF
--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -43,7 +43,7 @@ export default {
 
     // Text
     text: '#ffffff',
-    textSecondary: '#bbb',
+    textSecondary: '#bbbbbb',
     textTertiary: '#cccccc',
 
     // Backgrounds & Surface


### PR DESCRIPTION
Reanimated crashes with 'Invalid color value: #bbb08' when guest/detail.tsx appends 2-digit opacity suffix to the 3-digit short hex (e.g. #bbb + '08' = #bbb08, a malformed 5-digit hex). Expanding to 6-digit #bbbbbb produces the valid 8-digit ARGB form #bbbbbb08 after concatenation.