### PR TITLE
fix: hoist useThemeColor out of conditional JSX in article menu

### DIFF
--- a/app/article/[id].tsx
+++ b/app/article/[id].tsx
@@ -42,6 +42,7 @@ import { showToast } from '@/utils/toast';
 export default function ArticleDetail() {
   const colorScheme = useColorScheme();
   const primaryColor = useThemeColor({}, 'primary');
+  const warningColor = useThemeColor({}, 'warning');
   const { id, source } = useLocalSearchParams();
   const insets = useSafeAreaInsets();
   const router = useRouter();
@@ -569,7 +570,7 @@ export default function ArticleDetail() {
                 <MenuOption
                   icon={isCollected ? 'star' : 'star-outline'}
                   label={isCollected ? '取消收藏' : '移至收藏'}
-                  color={isCollected ? useThemeColor({}, 'warning') : undefined}
+                  color={isCollected ? warningColor : undefined}
                   onPress={() => {
                     collectMutation.mutate();
                     setMenuVisible(false);


### PR DESCRIPTION
## 问题

文章详情页在**已收藏**状态下点开「⋯」菜单会立即崩溃，报 `Rendered more hooks than during the previous render.`

`app/article/[id].tsx` 在 JSX 三元表达式里调用了 Hook：

```tsx
color={isCollected ? useThemeColor({}, 'warning') : undefined}
```

外层菜单块是条件渲染的（`{menuVisible && !isSharing && (...)}`），而 `useThemeColor` 内部包含 2 个 Hook。因此当 `isCollected` 为 true 时，打开菜单会使本次渲染的 Hook 数量比上次多 2 个，违反 Rules of Hooks。

## 复现

1. 打开一篇**已收藏**的普通文章（日报文章不请求收藏状态，不受影响）
2. 点击「⋯」
3. 立即崩溃

未收藏的文章不受影响，所以该问题此前容易被漏掉。

## 修复

将 `useThemeColor({}, 'warning')` 提升到组件顶层，与相邻一行 `Colors[colorScheme].danger` 的写法保持一致。解析出的颜色不变，仍为 `#ffb400`。

## 验证

- 在 React 19.2.0（项目所用版本）下构造最小复现：修复前「已收藏 + 打开菜单」必崩，修复后正常且颜色不变；未收藏路径修复前后均正常
- Android 真机 dev build 上确认
- `biome lint` 对该文件的 `correctness/useHookAtTopLevel` 报错消除
- `tsc --noEmit` 错误集合与修复前逐条一致（33 → 33，均为仓库既有问题），未引入新错误

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
