### PR TITLE
fix: escape regex metacharacters in search suggestion highlighting

### DIFF
--- a/app/search.tsx
+++ b/app/search.tsx
@@ -19,6 +19,11 @@ import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
 import { useSearchStore } from '@/store/useSearchStore';
 
+/** 转义正则元字符，避免用户输入（如 "C++"）构造出非法正则 */
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export default function SearchScreen() {
   const colorScheme = useColorScheme();
   const router = useRouter();
@@ -156,7 +161,7 @@ export default function SearchScreen() {
   const renderSuggestion = ({ item }: { item: any }) => {
     const text = item.query;
     if (!query) return null;
-    const parts = text.split(new RegExp(`(${query})`, 'gi'));
+    const parts = text.split(new RegExp(`(${escapeRegExp(query)})`, 'gi'));
     return (
       <Pressable
         className="flex-row items-center p-[15px]"


### PR DESCRIPTION
## 问题

在搜索框输入含正则元字符的内容会导致搜索页崩溃。`app/search.tsx` 将用户输入直接拼接进 `new RegExp()`：

```tsx
const parts = text.split(new RegExp(`(${query})`, 'gi'));
```

渲染搜索建议时抛出 `SyntaxError`，整页崩溃。

## 复现

在搜索框输入 `C++` —— 打到第三个字符即崩溃。输入 `(`、`[`、`?`、`\` 同样崩溃。

## 修复

构造正则前先转义元字符。

同时修复了一类**不崩溃但静默出错**的情况：`a|b`、`$1` 这类输入此前会因元字符改变匹配语义，导致高亮失效或高亮到错误位置。

## 验证

11 组用例对比（含无元字符的回归用例）：

- 修复前 6 例崩溃，`a|b` / `$1` 高亮失效
- 修复后 0 例崩溃，全部高亮位置正确；无元字符用例行为不变

`biome lint` 与 `tsc --noEmit` 的诊断数与修复前一致，未引入新问题。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
