### PR TITLE
fix: hoist remaining conditional useThemeColor calls out of conditional JSX

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -121,6 +121,7 @@ export default function HomeScreen() {
 
   const tintColor = useThemeColor({}, 'primary');
   const textColor = useThemeColor({}, 'text');
+  const indicatorBgColor = useThemeColor({}, 'primary_26');
   const [currentPage, setCurrentPage] = useState(initialPageIndex);
   const [guestCookieReady, setGuestCookieReady] = useState(false);
 
@@ -313,7 +314,7 @@ export default function HomeScreen() {
               <Animated.View
                 style={[
                   styles.topPill,
-                  { backgroundColor: useThemeColor({}, 'primary_26') },
+                  { backgroundColor: indicatorBgColor },
                   topIndicatorStyle,
                 ]}
               />
@@ -439,7 +440,7 @@ export default function HomeScreen() {
               style={[
                 styles.bottomIndicator,
                 {
-                  backgroundColor: useThemeColor({}, 'primary_26'),
+                  backgroundColor: indicatorBgColor,
                   width: bottomCapsuleWidth,
                 },
                 bottomIndicatorStyle,

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -31,6 +31,7 @@ export default function ProfileScreen() {
   const queryClient = useQueryClient();
   const { isDark, toggleTheme } = useThemeStore();
   const accentColor = useThemeColor({}, 'primary');
+  const accentBgColor = useThemeColor({}, 'primaryTransparent');
   const surfaceColor = Colors[colorScheme].surface;
   const textColor = Colors[colorScheme].text;
   const { enablePrivateMessaging } = useSettingsStore();
@@ -444,10 +445,7 @@ export default function ProfileScreen() {
                           <View
                             className="ml-2 px-1.5 py-0.5 rounded"
                             style={{
-                              backgroundColor: useThemeColor(
-                                {},
-                                'primaryTransparent',
-                              ),
+                              backgroundColor: accentBgColor,
                             }}
                           >
                             <Text
@@ -502,10 +500,7 @@ export default function ProfileScreen() {
                         <View
                           className="ml-2 px-1.5 py-0.5 rounded"
                           style={{
-                            backgroundColor: useThemeColor(
-                              {},
-                              'primaryTransparent',
-                            ),
+                            backgroundColor: accentBgColor,
                           }}
                         >
                           <Text

--- a/app/user/[id]/stream.tsx
+++ b/app/user/[id]/stream.tsx
@@ -685,7 +685,7 @@ export default function UserStreamScreen() {
         style={
           isHighlighted && {
             borderLeftWidth: 3,
-            borderLeftColor: useThemeColor({}, 'primary'),
+            borderLeftColor: primaryColor,
           }
         }
         onLayout={(event) => {

--- a/components/AnswerDetailView.tsx
+++ b/components/AnswerDetailView.tsx
@@ -218,6 +218,7 @@ export const AnswerDetailView = ({
 
   const primaryColor = useThemeColor({}, 'primary');
   const primaryTransparent = useThemeColor({}, 'primaryTransparent');
+  const warningColor = useThemeColor({}, 'warning');
 
   return (
     <View className="flex-1">
@@ -527,7 +528,7 @@ export const AnswerDetailView = ({
                 <MenuOption
                   icon={isCollected ? 'star' : 'star-outline'}
                   label={isCollected ? '取消收藏' : '移至收藏'}
-                  color={isCollected ? useThemeColor({}, 'warning') : undefined}
+                  color={isCollected ? warningColor : undefined}
                   onPress={() => {
                     collectMutation.mutate();
                     setMenuVisible(false);

--- a/components/CreationCard.tsx
+++ b/components/CreationCard.tsx
@@ -39,6 +39,7 @@ export const CreationCard = React.forwardRef(
     const router = useRouter();
     const colorScheme = useColorScheme();
     const primaryColor = useThemeColor({}, 'primary');
+    const warningColor = useThemeColor({}, 'warning');
     const [localExpanded, setLocalExpanded] = React.useState(false);
     const [menuVisible, setMenuVisible] = React.useState(false);
     const footerRef = React.useRef<NativeView>(null);
@@ -384,15 +385,13 @@ export const CreationCard = React.forwardRef(
                   <Ionicons
                     name={isCollected ? 'star' : 'star-outline'}
                     size={16}
-                    color={isCollected ? useThemeColor({}, 'warning') : '#888'}
+                    color={isCollected ? warningColor : '#888'}
                   />
                   {displayCount > 0 && (
                     <Text
                       className="ml-1 text-xs font-semibold"
                       style={{
-                        color: isCollected
-                          ? useThemeColor({}, 'warning')
-                          : '#888',
+                        color: isCollected ? warningColor : '#888',
                       }}
                     >
                       {displayCount}


### PR DESCRIPTION
## 问题

#24 修复了 `app/article/[id].tsx` 在条件 JSX 中调用 Hook 导致的崩溃,但同样的写法在代码库中仍有残留,造成两类真实崩溃(均为 `Rendered more hooks than during the previous render.`):

**崩溃 1 — 收藏夹详情页**:app 在后台且导航栈中停留在收藏夹详情页时,从外部链接打开一篇**已收藏**的文章。文章页将收藏状态写入 `useCollectionStore.collectedStatusMap`,后台 `CollectionDetailScreen` 列表中订阅同一 store 的 `CreationCard` 随之重渲染,`isCollected` 由 false 变 true,JSX 条件分支中的 `useThemeColor`(内含 2 个 Hook)被执行,Hook 数量陡增,立即崩溃。

**崩溃 2 — 回答页「⋯」菜单**:打开一篇**已收藏**的回答,点击「⋯」。条件渲染的菜单块(`{menuVisible && !isSharing && (...)}`)中的

```tsx
color={isCollected ? useThemeColor({}, 'warning') : undefined}
```

与 #24 修复的文章页完全同构,立即崩溃。回答页未被 #24 覆盖,故从链接打开已收藏回答后点菜单仍必崩。

全库扫描(`?`/`&&`/`:` 后跟 Hook 调用)共处理 8 处、5 个文件:

| 文件 | 处数 | 性质 |
| --- | --- | --- |
| `components/CreationCard.tsx` | 2 | 崩溃 1 根因(收藏星标图标与计数)|
| `components/AnswerDetailView.tsx` | 1 | 崩溃 2 根因(菜单收藏项)|
| `app/(tabs)/profile.tsx` | 2 | 同类隐患:「当前」徽标在条件块内,常见切换路径 Hook 数恰好守恒而未暴露 |
| `app/user/[id]/stream.tsx` | 1 | 同类隐患:`isHighlighted && {...}` 短路求值,Hook 是否执行取决于运行时值 |
| `app/(tabs)/index.tsx` | 2 | 当前无条件执行不会崩,一并提升以符合规范 |

## 复现

崩溃 1:
1. 进入包含某篇已收藏文章的收藏夹详情页
2. Home 键切后台(不清后台)
3. 在浏览器/微信中点击该文章链接,选择本应用打开
4. 立即崩溃

崩溃 2:
1. 清后台,从链接打开一篇**已收藏**的回答(冷启动)
2. 点击「⋯」
3. 立即崩溃

## 修复

与 #24 相同:将 `useThemeColor(...)` 提升到组件顶层后以变量引用(`stream.tsx` 直接复用组件内已有的 `primaryColor`,未新增调用)。所有位置解析出的颜色不变。

## 验证

- Android 真机(OnePlus PKX110 / Android 16)dev-client:崩溃 1 场景修复后正常打开,收藏星标颜色不变
- Android 真机本地 release 构建:崩溃 2 场景(清后台 → 链接冷启动 → 打开「⋯」菜单)修复后正常
- `biome check` 之 `correctness/useHookAtTopLevel`:涉及文件 6 → 0,其余诊断与 main 基线逐条一致(warnings 89 → 89),无新增
- `tsc --noEmit`:全库 0 错误

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
