### PR TITLE
fix: unify native link routing and suppress duplicate clipboard prompts

### DIFF
--- a/app/+native-intent.tsx
+++ b/app/+native-intent.tsx
@@ -1,0 +1,12 @@
+import { isExpoInternalUrl, parseZhihuUrl } from '@/utils/url';
+
+export function redirectSystemPath({
+  path,
+}: {
+  path: string;
+  initial: boolean;
+}): string {
+  if (isExpoInternalUrl(path)) return path;
+
+  return parseZhihuUrl(path) ?? path;
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -23,10 +23,10 @@ import {
   useSyncThemeWithNativeWind,
   useThemeStore,
 } from '@/store/useThemeStore';
-import { parseZhihuUrl } from '@/utils/url';
+import { isExpoInternalUrl, parseZhihuUrl } from '@/utils/url';
 import '../global.css';
 import * as Clipboard from 'expo-clipboard';
-import { AppState, type AppStateStatus } from 'react-native';
+import { AppState, type AppStateStatus, Linking } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Colors from '@/constants/Colors';
 import { useSettingsStore } from '@/store/useSettingsStore';
@@ -107,10 +107,28 @@ function RootLayout() {
   const [clipboardUrl, setClipboardUrl] = useState('');
 
   const lastCheckedUrlRef = useRef<string | null>(null);
+  const pendingExternalPathRef = useRef<string | null>(null);
+
+  // Observe hot-start links for clipboard de-duplication. Expo Router owns navigation.
+  useEffect(() => {
+    const subscription = Linking.addEventListener('url', ({ url }) => {
+      if (isExpoInternalUrl(url)) return;
+
+      pendingExternalPathRef.current = parseZhihuUrl(url);
+      setClipboardModalVisible(false);
+    });
+
+    return () => subscription.remove();
+  }, []);
 
   // Check clipboard for Zhihu links when app becomes active
   useEffect(() => {
     const handleAppStateChange = async (nextAppState: AppStateStatus) => {
+      if (nextAppState === 'background') {
+        pendingExternalPathRef.current = null;
+        return;
+      }
+
       if (nextAppState === 'active') {
         try {
           const hasText = await Clipboard.hasStringAsync();
@@ -128,6 +146,14 @@ function RootLayout() {
               );
               const url = urlMatch ? urlMatch[0] : null;
               if (url) {
+                const pendingExternalPath = pendingExternalPathRef.current;
+                pendingExternalPathRef.current = null;
+
+                if (parseZhihuUrl(url) === pendingExternalPath) {
+                  lastCheckedUrlRef.current = text;
+                  return;
+                }
+
                 setClipboardUrl(url);
                 setClipboardModalVisible(true);
               }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,7 +6,7 @@ import {
 import * as Sentry from '@sentry/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Constants from 'expo-constants';
-import { Stack, useRootNavigationState, useRouter } from 'expo-router';
+import { type Href, Stack, useRouter } from 'expo-router';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
@@ -26,7 +26,7 @@ import {
 import { parseZhihuUrl } from '@/utils/url';
 import '../global.css';
 import * as Clipboard from 'expo-clipboard';
-import { Alert, AppState, type AppStateStatus, Linking } from 'react-native';
+import { AppState, type AppStateStatus } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Colors from '@/constants/Colors';
 import { useSettingsStore } from '@/store/useSettingsStore';
@@ -74,7 +74,12 @@ const queryClient = new QueryClient({
   },
 });
 
+export const unstable_settings = {
+  initialRouteName: '(tabs)',
+};
+
 function RootLayout() {
+  const router = useRouter();
   const _colorScheme = useColorScheme();
   const isDark = useThemeStore((state) => state.isDark);
   const theme = isDark ? DarkTheme : DefaultTheme;
@@ -98,78 +103,8 @@ function RootLayout() {
     enableAutoRotation();
   }, []);
 
-  const router = useRouter();
-  const rootNavigationState = useRootNavigationState();
-  const isReady = !!rootNavigationState?.key;
-
-  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
-  const [isInitialUrl, setIsInitialUrl] = useState(false);
   const [clipboardModalVisible, setClipboardModalVisible] = useState(false);
   const [clipboardUrl, setClipboardUrl] = useState('');
-
-  // Handle deep links manually
-  useEffect(() => {
-    const handleUrl = (url: string | null) => {
-      if (!url) return;
-      // Skip internal Expo URLs
-      if (
-        url.includes('expo-development-client') ||
-        url.includes('expo-auth-session')
-      ) {
-        return;
-      }
-      setPendingUrl(url);
-    };
-
-    const subscription = Linking.addEventListener('url', (event) => {
-      handleUrl(event.url);
-    });
-
-    Linking.getInitialURL().then((url) => {
-      if (url) {
-        setIsInitialUrl(true);
-      }
-      handleUrl(url);
-    });
-
-    return () => {
-      subscription.remove();
-    };
-  }, []);
-
-  // Process pending URL when navigation is ready
-  useEffect(() => {
-    if (isReady && pendingUrl) {
-      const url = pendingUrl;
-      setPendingUrl(null); // Clear it
-
-      try {
-        const finalPath = parseZhihuUrl(url);
-        if (!finalPath) return;
-
-        console.log('[Deep Link] Processing URL:', url, '->', finalPath);
-
-        if (finalPath === '/') {
-          router.replace('/');
-          return;
-        }
-
-        if (isInitialUrl) {
-          console.log('[Deep Link] Cold start, setting home as root');
-          router.replace('/');
-          // Small delay to ensure replace completes before push
-          setTimeout(() => {
-            router.push(finalPath as any);
-          }, 100);
-          setIsInitialUrl(false);
-        } else {
-          router.push(finalPath as any);
-        }
-      } catch (err) {
-        console.error('[Deep Link] Navigation failed:', err);
-      }
-    }
-  }, [isReady, pendingUrl, isInitialUrl, router.push, router.replace]);
 
   const lastCheckedUrlRef = useRef<string | null>(null);
 
@@ -230,7 +165,10 @@ function RootLayout() {
               onClose={() => setClipboardModalVisible(false)}
               onOpen={() => {
                 setClipboardModalVisible(false);
-                setPendingUrl(clipboardUrl);
+                const path = parseZhihuUrl(clipboardUrl);
+                if (path) {
+                  router.push(path as Href);
+                }
               }}
             />
             <Stack

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -1,3 +1,10 @@
+export function isExpoInternalUrl(url: string): boolean {
+  return (
+    url.includes('expo-development-client') ||
+    url.includes('expo-auth-session')
+  );
+}
+
 /**
  * 解析并规范化知乎链接，将其转换为应用内的路由路径
  * @param url 原始 URL (可以是 http/https 链接，也可以是 deep link)


### PR DESCRIPTION
## 问题

Android 上从 Firefox 打开知乎文章时，浏览器会将

```text
https://zhuanlan.zhihu.com/p/<id>
```

改写为类似下面的自定义 URI：

```text
zhihu://articles/<id>?open=1&callback_source=...
```

当前代码同时存在两个系统深链导航所有者：

1. Expo Router 自动订阅系统 URL，并先按原始 `/articles/<id>` 路径导航；该路径没有对应文件路由，因此进入 `+not-found`
2. 根布局再次订阅同一个 URL，经 `parseZhihuUrl()` 改写为 `/article/<id>` 后手工 `router.push()`

热启动时实际栈为：

```text
首页 -> Not Found -> 文章
```

因此文章虽然能正常显示，但返回一次会出现 `This screen doesn't exist.`。与此同时，外部 Intent 使 App 回到 active 后，根布局又读取到浏览器地址栏中同一篇文章的剪贴板 URL，于是文章已经打开后仍弹出「发现知乎链接」。若点击「立即打开」，还会再压入一个相同文章实例。

手工导航中的 `isInitialUrl`、单槽 `pendingUrl` 和未取消的 100ms 定时器还会造成额外竞态：首页初始 URL 可令 `isInitialUrl` 永久残留，连续 Intent 也可能覆盖或颠倒。

## 复现

1. 先正常打开 App 并停留在首页
2. 在 Firefox 地址栏粘贴一篇知乎文章链接
3. 点击网页的「打开 App」，选择「知乎--」
4. 文章正常打开，但同时弹出剪贴板链接询问
5. 点击「忽略」后返回一次，进入 `This screen doesn't exist.`

点击「立即打开」时，修复前返回顺序为：同一文章 -> Not Found -> 首页 -> Firefox。

## 修复内容（按 commit）

1. **集中识别 Expo 内部 URL**
   - 抽出 `isExpoInternalUrl()`，避免 development-client 和 auth-session URL 被知乎路径规范化逻辑改写
2. **让 Expo Router 成为系统深链的唯一导航所有者**
   - 新增 `app/+native-intent.tsx`，在 Expo Router 建栈前调用现有 `parseZhihuUrl()`
   - 删除根布局中的 `Linking.getInitialURL()`、手工 URL 导航订阅、`pendingUrl`、`isInitialUrl` 和定时 `push`
   - 根 Stack 设置 `initialRouteName: '(tabs)'`，为冷启动详情页建立确定的首页返回层
   - 剪贴板弹窗的「立即打开」保留为普通应用内 `router.push()`
3. **仅抑制本次激活已经打开的剪贴板链接**
   - 根布局保留一个只观察、不执行导航的热启动 URL 订阅
   - 使用一次性的规范化路径 ref 与剪贴板 URL 比较
   - 两者相同则跳过弹窗；不同链接仍按原行为询问
   - 收到新外链时关闭可能残留的旧剪贴板弹窗

## 验证

- Android 真机：OnePlus PKX110 / Android 16
- `npx tsc --noEmit`：0 错误
- `npx biome lint app/_layout.tsx app/+native-intent.tsx utils/url.ts`：通过；仅保留 main 已有的 1 个 warning 和 2 个 info，无新增
- 表驱动检查 8 项：`https / zhihu:// / oia / 单复数 / 查询参数 / Expo 内部 URL` 全部通过
- `SENTRY_DISABLE_AUTO_UPLOAD=true ./gradlew app:assembleRelease`：BUILD SUCCESSFUL
- development-client URL 仍能正常连接 Metro
- release 真机回归：
  - 冷启动复数 `zhihu://articles/<id>`：文章 -> 首页
  - 热启动且剪贴板为同一文章：无弹窗，文章 -> 首页
  - 外部打开问题 B、剪贴板为文章 A：仍显示询问
  - 点击「立即打开」：文章 A -> 原问题 B -> 首页
  - 不支持的视频路径：仅一层 Not Found -> 首页（Intent Filter 收紧留给后续 PR）

## 未包含

本 PR 不改变应用接管的域名和路径范围，也不修改 HTTP URL 的域名校验规则。`video.zhihu.com`、过宽 `pathPrefix: "/"`、非知乎域名误识别及本应用自己复制链接后的提示，将在独立后续 PR 中处理，避免扩大本次导航生命周期修复的审查范围。

---

🤖 Generated with [Codex](https://openai.com/codex/)
