### PR TITLE
fix: harden Zhihu link handling and Android intent filters

### DIFF
--- a/app.json
+++ b/app.json
@@ -51,52 +51,139 @@
             {
               "scheme": "https",
               "host": "www.zhihu.com",
-              "pathPrefix": "/"
+              "pathPrefix": "/question/"
             },
             {
               "scheme": "https",
-              "host": "zhihu.com",
-              "pathPrefix": "/"
-            },
-            {
-              "scheme": "https",
-              "host": "zhuanlan.zhihu.com",
-              "pathPrefix": "/"
-            },
-            {
-              "scheme": "https",
-              "host": "oia.zhihu.com",
-              "pathPrefix": "/"
-            },
-            {
-              "scheme": "https",
-              "host": "video.zhihu.com",
-              "pathPrefix": "/"
-            },
-            {
-              "scheme": "http",
               "host": "www.zhihu.com",
-              "pathPrefix": "/"
+              "pathPrefix": "/answer/"
             },
             {
-              "scheme": "http",
+              "scheme": "https",
+              "host": "www.zhihu.com",
+              "pathPrefix": "/article/"
+            },
+            {
+              "scheme": "https",
+              "host": "www.zhihu.com",
+              "pathPrefix": "/pin/"
+            },
+            {
+              "scheme": "https",
+              "host": "www.zhihu.com",
+              "pathPrefix": "/people/"
+            },
+            {
+              "scheme": "https",
+              "host": "www.zhihu.com",
+              "pathPrefix": "/topic/"
+            },
+            {
+              "scheme": "https",
+              "host": "www.zhihu.com",
+              "pathPrefix": "/column/"
+            },
+            {
+              "scheme": "https",
+              "host": "www.zhihu.com",
+              "pathPrefix": "/collection/"
+            },
+            {
+              "scheme": "https",
               "host": "zhihu.com",
-              "pathPrefix": "/"
+              "pathPrefix": "/question/"
             },
             {
-              "scheme": "http",
+              "scheme": "https",
+              "host": "zhihu.com",
+              "pathPrefix": "/answer/"
+            },
+            {
+              "scheme": "https",
+              "host": "zhihu.com",
+              "pathPrefix": "/article/"
+            },
+            {
+              "scheme": "https",
+              "host": "zhihu.com",
+              "pathPrefix": "/pin/"
+            },
+            {
+              "scheme": "https",
+              "host": "zhihu.com",
+              "pathPrefix": "/people/"
+            },
+            {
+              "scheme": "https",
+              "host": "zhihu.com",
+              "pathPrefix": "/topic/"
+            },
+            {
+              "scheme": "https",
+              "host": "zhihu.com",
+              "pathPrefix": "/column/"
+            },
+            {
+              "scheme": "https",
+              "host": "zhihu.com",
+              "pathPrefix": "/collection/"
+            }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        },
+        {
+          "action": "VIEW",
+          "data": [
+            {
+              "scheme": "https",
               "host": "zhuanlan.zhihu.com",
-              "pathPrefix": "/"
-            },
+              "pathPrefix": "/p/"
+            }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        },
+        {
+          "action": "VIEW",
+          "data": [
             {
-              "scheme": "http",
+              "scheme": "https",
               "host": "oia.zhihu.com",
-              "pathPrefix": "/"
+              "pathPrefix": "/question/"
             },
             {
-              "scheme": "http",
-              "host": "video.zhihu.com",
-              "pathPrefix": "/"
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/questions/"
+            },
+            {
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/answer/"
+            },
+            {
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/answers/"
+            },
+            {
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/article/"
+            },
+            {
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/articles/"
+            },
+            {
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/pin/"
+            },
+            {
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/pins/"
             }
           ],
           "category": ["BROWSABLE", "DEFAULT"]
@@ -106,9 +193,6 @@
           "data": [
             {
               "scheme": "zhihu"
-            },
-            {
-              "scheme": "zhihu--"
             }
           ],
           "category": ["BROWSABLE", "DEFAULT"]

--- a/app/+native-intent.tsx
+++ b/app/+native-intent.tsx
@@ -5,8 +5,8 @@ export function redirectSystemPath({
 }: {
   path: string;
   initial: boolean;
-}): string {
+}): string | null {
   if (isExpoInternalUrl(path)) return path;
 
-  return parseZhihuUrl(path) ?? path;
+  return parseZhihuUrl(path);
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,6 +30,7 @@ import { AppState, type AppStateStatus, Linking } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Colors from '@/constants/Colors';
 import { useSettingsStore } from '@/store/useSettingsStore';
+import { consumeAppClipboardText } from '@/utils/clipboard';
 
 Sentry.init({
   dsn: 'https://93a6099dd49b040d9c516485eb3c72f6@o4511051860672512.ingest.de.sentry.io/4511051866112080',
@@ -134,6 +135,11 @@ function RootLayout() {
           const hasText = await Clipboard.hasStringAsync();
           if (hasText) {
             const text = await Clipboard.getStringAsync();
+            if (text && consumeAppClipboardText(text)) {
+              lastCheckedUrlRef.current = text;
+              return;
+            }
+
             if (
               text &&
               text !== lastCheckedUrlRef.current &&

--- a/components/FeedExcerpt.tsx
+++ b/components/FeedExcerpt.tsx
@@ -1,12 +1,9 @@
-import { useRouter } from 'expo-router';
+import { type Href, useRouter } from 'expo-router';
 import React, { useCallback, useMemo } from 'react';
+import { Linking } from 'react-native';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
-import {
-  extractZhihuRedirectTarget,
-  isInternalZhihuLink,
-  parseZhihuUrl,
-} from '@/utils/url';
+import { extractZhihuRedirectTarget, parseZhihuUrl } from '@/utils/url';
 import { Text, View } from './Themed';
 import { LinkCard } from './ZhihuContent';
 
@@ -80,10 +77,13 @@ export const FeedExcerpt: React.FC<{
     (url: string) => {
       if (!url) return;
       const realUrl = extractZhihuRedirectTarget(url);
-      if (!isInternalZhihuLink(realUrl)) return;
       const internalPath = parseZhihuUrl(realUrl);
       if (internalPath && internalPath !== '/') {
-        router.push(internalPath as any);
+        router.push(internalPath as Href);
+      } else {
+        Linking.openURL(realUrl).catch((err) =>
+          console.error('Failed to open URL:', err),
+        );
       }
     },
     [router],

--- a/components/ZhihuContent.tsx
+++ b/components/ZhihuContent.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useRouter } from 'expo-router';
+import { type Href, useRouter } from 'expo-router';
 import React, {
   useCallback,
   useEffect,
@@ -42,7 +42,6 @@ import { useSettingsStore } from '@/store/useSettingsStore';
 import { showToast } from '@/utils/toast';
 import {
   extractZhihuRedirectTarget,
-  isInternalZhihuLink,
   parseZhihuUrl,
 } from '@/utils/url';
 import { BouncyButton } from './BouncyButton';
@@ -88,22 +87,21 @@ export const LinkCard: React.FC<{
   surfaceColor: string;
   colorScheme: 'light' | 'dark';
 }> = React.memo(({ url, title, image, onPress, surfaceColor, colorScheme }) => {
-  const isInternal = url.includes('zhihu.com');
+  const internalPath = useMemo(() => parseZhihuUrl(url), [url]);
+  const isInternal = internalPath !== null;
   const primaryColor = useThemeColor({}, 'primary');
 
   const parsedId = useMemo(() => {
-    if (!url) return null;
-    const m = url.match(/zhihu\.com\/question\/(\d+)\/answer\/(\d+)/);
-    if (m) return { type: 'answer' as const, id: m[2] };
-    const qm = url.match(/zhihu\.com\/question\/(\d+)/);
-    if (qm && !url.includes('/answer/'))
-      return { type: 'question' as const, id: qm[1] };
-    const am = url.match(/zhuanlan\.zhihu\.com\/p\/(\d+)/);
-    if (am) return { type: 'article' as const, id: am[1] };
-    const pm = url.match(/zhihu\.com\/pin\/(\d+)/);
-    if (pm) return { type: 'pin' as const, id: pm[1] };
+    if (!internalPath) return null;
+    const match = internalPath.match(/^\/(question|answer|article|pin)\/(\d+)$/);
+    if (match) {
+      return {
+        type: match[1] as 'question' | 'answer' | 'article' | 'pin',
+        id: match[2],
+      };
+    }
     return null;
-  }, [url]);
+  }, [internalPath]);
 
   const { data: fetchedData } = useQuery({
     queryKey: ['linkcard', parsedId?.type, parsedId?.id],
@@ -544,16 +542,9 @@ export const ZhihuContent: React.FC<ZhihuContentProps> = React.memo(
         if (!url) return;
         // 先解码知乎跳转链接（link.zhihu.com?target=...），拿到真实 URL
         const realUrl = extractZhihuRedirectTarget(url);
-        // 非知乎链接直接用系统浏览器打开，不尝试 in-app 导航
-        if (!isInternalZhihuLink(realUrl)) {
-          Linking.openURL(realUrl).catch((err) =>
-            console.error('Failed to open URL:', err),
-          );
-          return;
-        }
         const internalPath = parseZhihuUrl(realUrl);
         if (internalPath && internalPath !== '/') {
-          router.push(internalPath as any);
+          router.push(internalPath as Href);
         } else {
           Linking.openURL(realUrl).catch((err) =>
             console.error('Failed to open URL:', err),

--- a/utils/clipboard.ts
+++ b/utils/clipboard.ts
@@ -1,5 +1,13 @@
 import { Alert, Share } from 'react-native';
 
+let pendingAppClipboardText: string | null = null;
+
+export const consumeAppClipboardText = (text: string): boolean => {
+  const wasCopiedByApp = pendingAppClipboardText === text;
+  pendingAppClipboardText = null;
+  return wasCopiedByApp;
+};
+
 /**
  * Safely copy text to clipboard.
  * Prevents crashes if the native expo-clipboard module is missing.
@@ -8,11 +16,14 @@ export const copyToClipboard = async (
   text: string,
   successMessage: string = '已复制到剪贴板',
 ) => {
+  pendingAppClipboardText = null;
+
   try {
     // Dynamic require to avoid top-level import crash
     const Clipboard = require('expo-clipboard');
     if (Clipboard && typeof Clipboard.setStringAsync === 'function') {
       await Clipboard.setStringAsync(text);
+      pendingAppClipboardText = text;
       // We assume showToast is available or we use Alert
       return true;
     }

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -1,8 +1,113 @@
 export function isExpoInternalUrl(url: string): boolean {
   return (
-    url.includes('expo-development-client') ||
-    url.includes('expo-auth-session')
+    url.includes('expo-development-client') || url.includes('expo-auth-session')
   );
+}
+
+const ZHIHU_WEB_HOSTS = new Set([
+  'zhihu.com',
+  'www.zhihu.com',
+  'zhuanlan.zhihu.com',
+  'oia.zhihu.com',
+]);
+
+const ZHIHU_APP_PROTOCOLS = new Set(['zhihu:', 'zhihu--:']);
+
+function extractPath(url: string): string | null {
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) return null;
+
+  if (!trimmedUrl.includes('://')) {
+    return trimmedUrl.startsWith('/') ? trimmedUrl : `/${trimmedUrl}`;
+  }
+
+  const parsedUrl = new URL(trimmedUrl);
+  if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+    if (!ZHIHU_WEB_HOSTS.has(parsedUrl.hostname.toLowerCase())) return null;
+    return parsedUrl.pathname;
+  }
+
+  if (ZHIHU_APP_PROTOCOLS.has(parsedUrl.protocol.toLowerCase())) {
+    const host = parsedUrl.hostname ? `/${parsedUrl.hostname}` : '';
+    return `${host}${parsedUrl.pathname}` || '/';
+  }
+
+  return null;
+}
+
+function normalizeSupportedPath(path: string): string | null {
+  const cleanPath = path.split(/[?#]/, 1)[0].replace(/\/+$/, '') || '/';
+  const withoutOia = cleanPath.replace(/^\/oia(?=\/|$)/, '') || '/';
+
+  if (
+    withoutOia === '/' ||
+    withoutOia === '/feed' ||
+    withoutOia === '/home' ||
+    withoutOia === '/follow'
+  ) {
+    return '/';
+  }
+
+  const questionAnswerMatch = withoutOia.match(
+    /^\/questions?\/(\d+)\/answers?\/(\d+)$/,
+  );
+  if (questionAnswerMatch) return `/answer/${questionAnswerMatch[2]}`;
+
+  const routePatterns: Array<{
+    pattern: RegExp;
+    buildPath: (match: RegExpMatchArray) => string;
+  }> = [
+    {
+      pattern: /^\/questions?\/(\d+)$/,
+      buildPath: (match) => `/question/${match[1]}`,
+    },
+    {
+      pattern: /^\/answers?\/(\d+)$/,
+      buildPath: (match) => `/answer/${match[1]}`,
+    },
+    {
+      pattern: /^\/(?:articles?|p)\/(\d+)$/,
+      buildPath: (match) => `/article/${match[1]}`,
+    },
+    {
+      pattern: /^\/pins?\/(\d+)$/,
+      buildPath: (match) => `/pin/${match[1]}`,
+    },
+    {
+      pattern:
+        /^\/(?:people|users?)\/([^/]+)(?:\/(followers|following|mutual|stream))?$/,
+      buildPath: (match) =>
+        `/user/${match[1]}${match[2] ? `/${match[2]}` : ''}`,
+    },
+    {
+      pattern: /^\/topics?\/([^/]+)$/,
+      buildPath: (match) => `/topic/${match[1]}`,
+    },
+    {
+      pattern: /^\/columns?\/([^/]+)$/,
+      buildPath: (match) => `/column/${match[1]}`,
+    },
+    {
+      pattern: /^\/collections?\/(\d+)$/,
+      buildPath: (match) => `/collections/${match[1]}`,
+    },
+  ];
+
+  for (const { pattern, buildPath } of routePatterns) {
+    const match = withoutOia.match(pattern);
+    if (match) return buildPath(match);
+  }
+
+  // Zhihu app links sometimes contain only a resource ID.
+  if (/^\/\d{15,25}$/.test(withoutOia)) {
+    const id = withoutOia.substring(1);
+    return id.startsWith('19') ? `/question/${id}` : `/answer/${id}`;
+  }
+  if (/^\/\d{8,14}$/.test(withoutOia)) {
+    return `/question/${withoutOia.substring(1)}`;
+  }
+
+  return null;
 }
 
 /**
@@ -13,63 +118,9 @@ export function isExpoInternalUrl(url: string): boolean {
 export function parseZhihuUrl(url: string | null): string | null {
   if (!url) return null;
 
-  // 1. 提取路径部分
-  let path = '';
   try {
-    if (url.includes('://')) {
-      const parts = url.split('://');
-      const rest = parts[1] !== undefined ? parts[1] : '';
-
-      if (url.startsWith('http')) {
-        // 处理 http(s) 链接: https://www.zhihu.com/question/123 -> /question/123
-        const match = rest.match(/^[^/]+(\/.*)$/);
-        path = match ? match[1] : '/';
-      } else {
-        // 处理自定义 scheme: zhihu://question/123 -> /question/123
-        path = rest.startsWith('/') ? rest : '/' + rest;
-      }
-    } else {
-      // 已经是路径形式
-      path = url.startsWith('/') ? url : '/' + url;
-    }
-
-    // 2. 规范化路径：移除 oia (移动端优化页前缀), 统一单复数
-    path = path.replace(/^\/oia\//, '/');
-    path = path.replace(/^\/questions?\//, '/question/');
-    path = path.replace(/^\/answers?\//, '/answer/');
-    path = path.replace(/^\/people\//, '/user/');
-    path = path.replace(/^\/articles?\//, '/article/');
-    path = path.replace(/^\/p\//, '/article/');
-    path = path.replace(/^\/pins?\//, '/pin/');
-
-    // 3. 清理查询参数
-    const cleanPath = path.split('?')[0];
-
-    // 4. 处理首页/空路径
-    if (
-      !cleanPath ||
-      cleanPath === '/' ||
-      cleanPath === '/oia' ||
-      cleanPath === '/feed' ||
-      cleanPath === '/home' ||
-      cleanPath === '/follow'
-    ) {
-      return '/';
-    }
-
-    // 5. 特殊处理：裸 ID 启发式判断 (知乎深度链接有时只带 ID)
-    // 裸的长 ID (15-25位): 通常是回答 ID 或问题 ID
-    if (/^\/\d{15,25}$/.test(cleanPath)) {
-      const id = cleanPath.substring(1);
-      // 知乎问题 ID 通常以 19 开头（目前规律），否则可能是回答 ID
-      return id.startsWith('19') ? `/question/${id}` : `/answer/${id}`;
-    }
-    // 裸的短 ID (8-14位): 通常是问题 ID
-    else if (/^\/\d{8,14}$/.test(cleanPath)) {
-      return `/question/${cleanPath.substring(1)}`;
-    }
-
-    return cleanPath;
+    const path = extractPath(url);
+    return path ? normalizeSupportedPath(path) : null;
   } catch (err) {
     console.error('[URL Parser] Failed to parse:', url, err);
     return null;
@@ -80,11 +131,7 @@ export function parseZhihuUrl(url: string | null): string | null {
  * 判断是否为知乎内部链接
  */
 export function isInternalZhihuLink(url: string): boolean {
-  return (
-    url.includes('zhihu.com') ||
-    url.startsWith('zhihu://') ||
-    url.startsWith('/')
-  );
+  return parseZhihuUrl(url) !== null;
 }
 
 /**
@@ -93,10 +140,13 @@ export function isInternalZhihuLink(url: string): boolean {
  */
 export function extractZhihuRedirectTarget(url: string): string {
   try {
-    if (url.includes('link.zhihu.com')) {
-      const parsed = new URL(url);
+    const parsed = new URL(url);
+    if (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+      parsed.hostname.toLowerCase() === 'link.zhihu.com'
+    ) {
       const target = parsed.searchParams.get('target');
-      if (target) return decodeURIComponent(target);
+      if (target) return target;
     }
   } catch (_) {}
   return url;


### PR DESCRIPTION
## 背景

#29 已将系统深链导航统一交给 Expo Router，并解决了正确页面下方残留 Not Found、同一外链重复触发剪贴板询问等生命周期问题。该 PR 刻意没有改变应用接管的域名和路径范围。

本 PR 是 #29 的后续加固：统一“哪些知乎链接可由应用处理”的边界，并让 URL 解析、内容点击、剪贴板检测与 Android Intent Filter 使用同一组能力范围。

## 问题

当前链接边界仍有四类问题：

1. **URL 解析不校验真实域名或受支持路由**
   - `parseZhihuUrl()` 只提取路径，任意域名上的 `/question/<id>` 等形状都可能被当作应用内链接
   - `isInternalZhihuLink()` 使用 `includes('zhihu.com')`，会误判 `evilzhihu.com`
   - 未知知乎路径会原样进入 Expo Router，最终显示 Not Found
   - `link.zhihu.com` 仅以子串判断，目标参数还会被重复解码
2. **内容链接行为不一致**
   - `FeedExcerpt` 遇到外部或不支持的链接时直接无响应
   - `ZhihuContent`、LinkCard 标识和预取逻辑各自维护不同的正则与判断规则
3. **应用会重新询问自己写入的剪贴板**
   - 在应用内点击“复制链接”后切出再返回，同一链接仍可能触发「发现知乎链接」弹窗
4. **Android 接管范围大于应用能力范围**
   - `video.zhihu.com`、HTTP 和知乎各域名下的任意路径都会被应用接管
   - 视频、设置、登录等项目没有对应路由的页面仍会把用户带入应用

## 复现

- 打开 `https://video.zhihu.com/...` 或 `https://www.zhihu.com/settings/...`，系统仍会把链接交给本应用，随后停在 Not Found
- 内容中出现真正的外部链接时，Feed 卡片点击后没有任何响应
- 在文章页复制链接，切到桌面再恢复应用，会被自己刚复制的链接再次询问
- `https://evilzhihu.com/question/<id>` 等伪造域名可能通过旧的“知乎内部链接”判断

## 修复内容（按 commit）

1. **严格校验知乎 URL 与应用支持的路由**
   - 使用标准 `URL` 解析协议、精确 hostname 和 pathname
   - 仅接受 `zhihu.com`、`www.zhihu.com`、`zhuanlan.zhihu.com`、`oia.zhihu.com` 及官方/本应用自定义 scheme
   - 将问题、回答、文章、想法、用户、话题、专栏、收藏夹及已知单双数别名规范化为现有文件路由
   - 不支持的路径返回 `null`；`+native-intent` 因此保持当前页面，不再导航到 Not Found
   - 仅在 hostname 精确为 `link.zhihu.com` 时提取 `target`，并依赖 `URLSearchParams` 执行一次解码
2. **统一内容链接点击与 LinkCard 判断**
   - 可解析的知乎内容继续使用应用内路由
   - 外链及不支持的知乎页面统一交给系统浏览器
   - `FeedExcerpt` 不再静默吞掉外链
   - LinkCard 的内部标识与详情预取复用规范化结果，不再重复维护域名和路径正则
3. **忽略本应用刚写入的剪贴板内容**
   - `copyToClipboard()` 成功后记录一次性、进程内的文本来源标记
   - App 恢复 active 时，若剪贴板文本完全相同则消费标记并跳过弹窗
   - 不同文本仍按原逻辑检查，不会屏蔽其他应用写入的新链接
4. **收窄 Android Intent Filter**
   - 仅接管 HTTPS 下项目实际支持的内容路径
   - `zhuanlan.zhihu.com` 仅接管 `/p/`，OIA 使用独立允许列表
   - 移除 `video.zhihu.com`、HTTP 和整站 `pathPrefix: "/"`
   - 将主站、专栏和 OIA 拆为独立 filter，避免 Android 合并同一 filter 内 `<data>` 属性后形成意外交叉组合
   - 保留知乎官方 `zhihu://` 兼容；本应用的 `zhihu--` 已由 Expo 顶层 `scheme` 声明，不再重复配置

## 验证

- Android 真机：OnePlus PKX110 / Android 16
- `npx tsc --noEmit`：0 错误
- `npx expo config --type public --json`：配置解析通过
- URL 表驱动检查 42 项通过，覆盖：
  - HTTPS、`zhihu://`、`zhihu--://`、OIA、单双数别名、查询参数和裸 ID
  - 精确域名、伪造子域名、凭据混淆、未知协议及不支持路径拒绝
  - `link.zhihu.com` 单次解码与伪造跳转域名拒绝
- Intent Filter 检查 15 项通过：支持的文章/问题路径被接管；视频、设置、HTTP、伪造域名和错误的跨域路径不被接管
- `git diff --check upstream/main...HEAD`：通过
- Biome：本次新增行无 lint error；定向检查仍报告 8 个 `main` 已有错误，均位于本 PR 未修改的历史代码行
- `SENTRY_DISABLE_AUTO_UPLOAD=true ./gradlew app:assembleRelease`：BUILD SUCCESSFUL
- release 真机回归：
  - 支持的文章、问题链接仍由正式包接管
  - 视频、设置、HTTP、伪造域名和错误专栏路径不再由正式包接管
  - 应用内复制链接后重新进入应用，不再弹出剪贴板询问
  - 冷启动文章后返回首页正常
  - 即使显式投递不支持的知乎 URI，也保持在首页，不进入 Not Found

## 未包含

- 本 PR 不新增视频、设置、登录等页面的应用内路由；这些页面明确回退到浏览器
- 剪贴板来源标记只在当前进程中一次性生效，不引入持久化状态
- 不清理 `FeedExcerpt`、`ZhihuContent` 等文件中与本次链接修改无关的既有 Biome 问题，避免扩大审查差异

---

🤖 Generated with [Codex](https://openai.com/codex/)