### PR TITLE
chore: enforce LF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,json,jsx,ts,tsx}]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+
+*.gif binary
+*.ico binary
+*.jpeg binary
+*.jpg binary
+*.keystore binary
+*.otf binary
+*.png binary
+*.ttf binary
+*.webp binary

--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,8 @@
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "indentWidth": 2
+    "indentWidth": 2,
+    "lineEnding": "lf"
   },
   "linter": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- enforce LF checkout and normalization through `.gitattributes`
- align supported editors through `.editorconfig`
- configure Biome to format files with LF on every platform
- keep binary assets exempt from text normalization

## Verification

- all 145 tracked LF text files report LF in the current worktree
- `npx biome check biome.json` passes
- the repository-wide Biome format check no longer reports CRLF-only differences; 5 pre-existing, non-line-ending format issues remain
- `git diff --cached --check` passed before commit

The tracked repository content was already normalized to LF, so this PR intentionally contains only the enforcement configuration and no repository-wide mechanical code diff.
