### PR TITLE
chore: fix the unambiguous biome diagnostics

### DIFF
--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -22,7 +22,10 @@ export default function Root({ children }: { children: React.ReactNode }) {
         <ScrollViewStyleReset />
 
         {/* Using raw CSS styles as an escape-hatch to ensure the background color never flickers in dark-mode. */}
-        <style dangerouslySetInnerHTML={{ __html: responsiveBackground }} />
+        <style
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: Expo Router 官方 HTML shell 的固定写法,注入的是本文件末尾的常量模板字符串,不含任何外部输入。
+          dangerouslySetInnerHTML={{ __html: responsiveBackground }}
+        />
         {/* Add any additional <head> elements that you want globally available on web... */}
       </head>
       <body>{children}</body>

--- a/app/answer/[id].tsx
+++ b/app/answer/[id].tsx
@@ -84,6 +84,7 @@ export default function AnswerDetailScreen() {
       );
       return res.data;
     },
+    initialPageParam: 0,
     enabled: !!questionId,
   });
 

--- a/app/pin/[id].tsx
+++ b/app/pin/[id].tsx
@@ -9,7 +9,6 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
-  useWindowDimensions,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { addReadHistory } from '@/api/zhihu/history';
@@ -31,7 +30,6 @@ export default function PinDetailScreen() {
   const { id } = useLocalSearchParams();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { width } = useWindowDimensions();
   const _queryClient = useQueryClient();
   const textColor = Colors[colorScheme].text;
   const borderColor = Colors[colorScheme].border;

--- a/app/question/[id]/index.tsx
+++ b/app/question/[id]/index.tsx
@@ -59,7 +59,6 @@ import { useScrollHeaderAnim } from '@/hooks/useScrollAnimation';
 import { useViewableItems } from '@/hooks/useViewableItems';
 import { useZhihuInfiniteQuery } from '@/hooks/useZhihuInfiniteQuery';
 import { useCollectionStore } from '@/store/useCollectionStore';
-import { useProgressStore } from '@/store/useProgressStore';
 import { useSettingsStore } from '@/store/useSettingsStore';
 import { formatDate } from '@/utils/date';
 import { refreshInfiniteQuery } from '@/utils/query';
@@ -662,7 +661,6 @@ export default function QuestionDetail() {
     }, 500);
   };
 
-  const { saveProgress, getProgress } = useProgressStore();
   const [isRestored, setIsRestored] = useState(false);
 
   const [sortBy, setSortBy] = useState<'default' | 'created'>('default');

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -99,7 +99,12 @@ export default function SearchScreen() {
         {parts.map((part, i) => {
           if (part.startsWith('[[EM]]') && part.endsWith('[[/EM]]')) {
             return (
-              <Text key={i} type="primary" className="font-bold">
+              <Text
+                // biome-ignore lint/suspicious/noArrayIndexKey: parts 是同一段文本按 [[EM]] 标记 split 出的片段,数量与顺序由该次渲染的文本唯一决定,不增删也不重排。
+                key={i}
+                type="primary"
+                className="font-bold"
+              >
                 {part.replace(/\[\[\/?EM\]\]/g, '')}
               </Text>
             );
@@ -184,7 +189,11 @@ export default function SearchScreen() {
         <Text className="text-base">
           {parts.map((p: string, i: number) =>
             p.toLowerCase() === query.toLowerCase() ? (
-              <Text key={i} style={{ color: tintColor, fontWeight: 'bold' }}>
+              <Text
+                // biome-ignore lint/suspicious/noArrayIndexKey: parts 是搜索词按 query split 出的片段,数量与顺序由该次渲染的建议文本唯一决定。
+                key={i}
+                style={{ color: tintColor, fontWeight: 'bold' }}
+              >
                 {p}
               </Text>
             ) : (
@@ -370,9 +379,9 @@ export default function SearchScreen() {
                 </Pressable>
               </View>
               <View className="flex-row flex-wrap">
-                {history.map((item, index) => (
+                {history.map((item) => (
                   <View
-                    key={index}
+                    key={item}
                     className="flex-row items-center rounded-[15px] pl-3 pr-2 py-1.5 mr-2.5 mb-2.5"
                     style={{ backgroundColor: surfaceColor }}
                   >

--- a/app/settings/appearance.tsx
+++ b/app/settings/appearance.tsx
@@ -683,7 +683,10 @@ function Section({
         {childArray.map((child, index) => {
           const isLast = index === childArray.length - 1;
           return (
-            <RNView key={index}>
+            <RNView
+              // biome-ignore lint/suspicious/noArrayIndexKey: childArray 来自 React.Children,子元素在调用处的 JSX 里逐个写死,数量与顺序在编译期就固定了。
+              key={index}
+            >
               {child}
               {!isLast && (
                 <RNView
@@ -886,7 +889,11 @@ function HslSlider({
         }}
       >
         {gradientColors.map((color: string, i: number) => (
-          <RNView key={i} style={{ flex: 1, backgroundColor: color }} />
+          <RNView
+            // biome-ignore lint/suspicious/noArrayIndexKey: gradientColors 是固定长度的预设色序,渲染的是无状态色块;色值本身会重复,不能当 key。
+            key={i}
+            style={{ flex: 1, backgroundColor: color }}
+          />
         ))}
       </RNView>
       {trackWidth > 0 && (

--- a/app/topic/[id].tsx
+++ b/app/topic/[id].tsx
@@ -238,7 +238,7 @@ export default function TopicDetail() {
             {activeTab === 'structure' && (
               <TopicStructureView
                 parents={parentsData?.data || []}
-                children={childrenData?.data || []}
+                childTopics={childrenData?.data || []}
                 bestAnswerers={bestAnswerersData?.data || []}
                 isLoading={
                   parentsLoading || childrenLoading || bestAnswerersLoading
@@ -291,12 +291,12 @@ export default function TopicDetail() {
 
 function TopicStructureView({
   parents,
-  children,
+  childTopics,
   bestAnswerers,
   isLoading,
 }: {
   parents: any[];
-  children: any[];
+  childTopics: any[];
   bestAnswerers: any[];
   isLoading: boolean;
 }) {
@@ -370,11 +370,11 @@ function TopicStructureView({
         </View>
       )}
 
-      {children.length > 0 && (
+      {childTopics.length > 0 && (
         <View className="px-5 py-4 bg-transparent">
           <Text className="text-base font-bold mb-3">子话题</Text>
           <View className="flex-row flex-wrap bg-transparent">
-            {children.map((topic: any) => (
+            {childTopics.map((topic: any) => (
               <TopicItem key={topic.id} topic={topic} />
             ))}
           </View>
@@ -382,7 +382,7 @@ function TopicStructureView({
       )}
 
       {parents.length === 0 &&
-        children.length === 0 &&
+        childTopics.length === 0 &&
         bestAnswerers.length === 0 && (
           <View className="p-10 items-center bg-transparent">
             <Text type="secondary">暂无话题层级数据</Text>

--- a/app/user/[id]/index.tsx
+++ b/app/user/[id]/index.tsx
@@ -486,6 +486,7 @@ export default function UserDetailScreen() {
         {parts.map((part, i) =>
           part.startsWith('[[EM]]') && part.endsWith('[[/EM]]') ? (
             <Text
+              // biome-ignore lint/suspicious/noArrayIndexKey: parts 是同一段文本按 [[EM]] 标记 split 出的片段,数量与顺序由该次渲染的文本唯一决定,不增删也不重排。
               key={i}
               type="primary"
               className="font-bold"

--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,15 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noUnknownAtRules": {
+          "level": "on",
+          "options": {
+            "ignore": ["tailwind", "apply", "layer", "config", "screen"]
+          }
+        }
+      }
     }
   },
   "javascript": {

--- a/components/AnswerDetailView.tsx
+++ b/components/AnswerDetailView.tsx
@@ -12,7 +12,6 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
-  useWindowDimensions,
 } from 'react-native';
 import { SharedTransition } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -32,7 +31,6 @@ import { Text, ThemedIcon, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import { ZhihuContent } from '@/components/ZhihuContent';
 import Colors from '@/constants/Colors';
-import { useCollectionAction } from '@/hooks/useCollectionAction';
 import { useOptimisticToggle } from '@/hooks/useOptimisticToggle';
 import { useScrollHeaderAnim } from '@/hooks/useScrollAnimation';
 import { useCollectionStore } from '@/store/useCollectionStore';
@@ -59,7 +57,6 @@ export const AnswerDetailView = ({
 }: AnswerDetailViewProps) => {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { width } = useWindowDimensions();
 
   const colorScheme = useColorScheme();
   const surfaceColor = Colors[colorScheme].surface;
@@ -160,8 +157,6 @@ export const AnswerDetailView = ({
   const favoritedCollection = collectionStatus?.data?.find(
     (item: any) => item.is_favorited,
   );
-
-  const { toggleCollect } = useCollectionAction();
 
   const storeCollected = useCollectionStore(
     (state) => state.collectedStatusMap[id.toString()],

--- a/components/CommentContent.tsx
+++ b/components/CommentContent.tsx
@@ -67,7 +67,11 @@ export const CommentContent: React.FC<CommentContentProps> = ({
 
       {/* 渲染提取出的图片卡片（独占整行） */}
       {imageUrls.map((url, idx) => (
-        <View key={`${url}-${idx}`} className="bg-transparent my-1.5 w-full">
+        <View
+          // biome-ignore lint/suspicious/noArrayIndexKey: 同一条评论可以重复引用同一张图,url 不唯一,复合 key 才能保证不撞。
+          key={`${url}-${idx}`}
+          className="bg-transparent my-1.5 w-full"
+        >
           <BouncyButton
             onPress={() => handleOpenImage(url)}
             className="flex-row items-center p-2 rounded-xl border border-dashed border-gray-300 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-800/20"

--- a/components/FeedExcerpt.tsx
+++ b/components/FeedExcerpt.tsx
@@ -119,6 +119,7 @@ export const FeedExcerpt: React.FC<{
       ) : null}
       {parsed.links.map((link, i) => (
         <LinkCard
+          // biome-ignore lint/suspicious/noArrayIndexKey: link 不能当 key —— 缺 url 的 link_card 会回落成空串(见上方 parsePinContent 的 map),多张卡片就会撞;正则提取的那条路径也不去重。
           key={i}
           url={link}
           onPress={handleLinkPress}

--- a/components/MathView.tsx
+++ b/components/MathView.tsx
@@ -41,6 +41,7 @@ export default function MathView({
         }
       `}</style>
       <span
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: KaTeX 的渲染结果只能这样注入。formula 虽来自知乎正文,但 renderToString 的 trust 选项默认为 false,\href/\url/\includegraphics 等可注入 URL 或 HTML 的命令会被拒绝渲染,输出不含可执行内容。
         dangerouslySetInnerHTML={{ __html: html }}
         style={{
           fontSize: '17px',

--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -4,6 +4,7 @@ import { ActivityIndicator, Image, Pressable } from 'react-native';
 import { followMember, unfollowMember } from '@/api/zhihu';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
+import type { ZhihuBadge } from '@/types/zhihu';
 import { Text, useThemeColor, View } from './Themed';
 export const UserCard = ({ user }: { user: any }) => {
   const router = useRouter();
@@ -56,7 +57,7 @@ export const UserCard = ({ user }: { user: any }) => {
           <Text className="text-base font-semibold" numberOfLines={1}>
             {user.name}
           </Text>
-          {user.badge?.find((b: any) => b.type === 'best_answerer') && (
+          {user.badge?.find((b: ZhihuBadge) => b.type === 'best_answerer') && (
             <View className="ml-1.5 px-1 py-px rounded bg-[#fffbe6] border-[0.5px] border-[#ffe58f]">
               <Text className="text-[10px] font-bold text-[#d48806]">
                 优秀回答者

--- a/components/ZhihuContent.tsx
+++ b/components/ZhihuContent.tsx
@@ -419,7 +419,6 @@ const LazyImage: React.FC<{
 const IMG_Renderer: CustomBlockRenderer = ({ tnode }) => {
   const { src, width: attrWidth, height: attrHeight, eeimg } = tnode.attributes;
   const rendererProps = useRendererProps('img');
-  const { useWebView } = useSettingsStore();
   const [svgError, setSvgError] = useState(false);
 
   if (!rendererProps) return null;

--- a/components/ZhihuContent.tsx
+++ b/components/ZhihuContent.tsx
@@ -325,6 +325,7 @@ const P_Renderer: CustomBlockRenderer = ({ TDefaultRenderer, ...props }) => {
         if (slice.interaction) {
           return (
             <Text
+              // biome-ignore lint/suspicious/noArrayIndexKey: slices 是单个 segment 一次性切分出的结果,同一 segment 的切分稳定;slice.text 会重复,不能当 key。
               key={idx}
               onPress={() => onPress(pid, segment, slice.interaction)}
               style={{
@@ -342,6 +343,7 @@ const P_Renderer: CustomBlockRenderer = ({ TDefaultRenderer, ...props }) => {
         }
         return (
           <Text
+            // biome-ignore lint/suspicious/noArrayIndexKey: 同上,与相邻分支共用一次 slices.map。
             key={idx}
             style={{
               color: textColor,
@@ -951,6 +953,7 @@ export const ZhihuContent: React.FC<ZhihuContentProps> = React.memo(
         if (item.type === 'text') {
           return (
             <RenderHtml
+              // biome-ignore lint/suspicious/noArrayIndexKey: contentArray 是想法正文的解析结果,按原文顺序混排文本/图片/链接卡片。PinContentItem 没有 id,内容本身也不保证唯一,index 是这里唯一稳定的标识。
               key={index}
               contentWidth={width - 40}
               source={{ html: `<div>${item.content}</div>` }}
@@ -968,6 +971,7 @@ export const ZhihuContent: React.FC<ZhihuContentProps> = React.memo(
         if (item.type === 'image') {
           return (
             <View
+              // biome-ignore lint/suspicious/noArrayIndexKey: 同上,与相邻分支共用一次 contentArray.map。
               key={index}
               className="my-2.5 items-center w-full bg-transparent"
             >
@@ -990,6 +994,7 @@ export const ZhihuContent: React.FC<ZhihuContentProps> = React.memo(
         if (item.type === 'link_card') {
           return (
             <LinkCard
+              // biome-ignore lint/suspicious/noArrayIndexKey: 同上,与相邻分支共用一次 contentArray.map。
               key={index}
               url={item.url}
               title={item.data_draft_title}

--- a/hooks/useZhihuInfiniteQuery.ts
+++ b/hooks/useZhihuInfiniteQuery.ts
@@ -1,13 +1,50 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import {
+  type DefaultError,
+  type InfiniteData,
+  type QueryKey,
+  type UseInfiniteQueryOptions,
+  useInfiniteQuery,
+} from '@tanstack/react-query';
 
-export function useZhihuInfiniteQuery<_TData = any>(options: any) {
+/**
+ * 知乎列表接口共有的分页结构。getNextPageParam 只读这一部分,
+ * 所以调用方的页数据类型只需要满足它。
+ */
+export interface ZhihuPaginatedPage {
+  paging?: {
+    is_end?: boolean;
+    next?: string;
+  };
+}
+
+/**
+ * useInfiniteQuery 的知乎特化版本:统一从 paging.next 的 offset 查询参数
+ * 推导下一页的 pageParam。除 getNextPageParam 由本 hook 提供外,
+ * 其余选项与 useInfiniteQuery 完全一致。
+ */
+export function useZhihuInfiniteQuery<
+  TQueryFnData extends ZhihuPaginatedPage,
+  TError = DefaultError,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: Omit<
+    UseInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      InfiniteData<TQueryFnData, number>,
+      TQueryKey,
+      number
+    >,
+    'getNextPageParam'
+  >,
+) {
   return useInfiniteQuery({
     ...options,
-    getNextPageParam: (lastPage: any) => {
+    getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
       const nextUrl = lastPage.paging?.next;
       const match = nextUrl?.match(/offset=(\d+)/);
       return match ? parseInt(match[1], 10) : undefined;
     },
-  } as any) as any;
+  });
 }

--- a/types/zhihu.ts
+++ b/types/zhihu.ts
@@ -11,7 +11,7 @@ export interface ZhihuDetailBadge {
   url?: string;
   icon?: string;
   night_icon?: string;
-  sources?: any[];
+  sources?: unknown[];
 }
 
 export interface ZhihuMergedBadge {
@@ -22,15 +22,15 @@ export interface ZhihuMergedBadge {
   url?: string;
   icon?: string;
   night_icon?: string;
-  sources?: any[];
+  sources?: unknown[];
 }
 
 export interface ZhihuBadgeV2 {
   title: string;
   icon: string;
   night_icon: string;
-  detail_badges?: ZhihuDetailBadge[] | any[];
-  merged_badges?: ZhihuMergedBadge[] | any[];
+  detail_badges?: ZhihuDetailBadge[];
+  merged_badges?: ZhihuMergedBadge[];
 }
 
 export interface ZhihuAuthor {
@@ -48,7 +48,7 @@ export interface ZhihuAuthor {
   is_advertiser?: boolean;
   is_privacy?: boolean;
   is_following?: boolean;
-  badge?: ZhihuBadge[] | any[];
+  badge?: ZhihuBadge[];
   badge_v2?: ZhihuBadgeV2;
 }
 

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -1,4 +1,8 @@
-import type { QueryClient } from '@tanstack/react-query';
+import type {
+  InfiniteData,
+  QueryClient,
+  QueryKey,
+} from '@tanstack/react-query';
 
 /**
  * Custom refresh handler for TanStack useInfiniteQuery.
@@ -12,15 +16,19 @@ import type { QueryClient } from '@tanstack/react-query';
  */
 export async function refreshInfiniteQuery(
   queryClient: QueryClient,
-  queryKey: any[],
-  refetch: () => Promise<any>,
+  queryKey: QueryKey,
+  refetch: () => Promise<unknown>,
 ) {
-  queryClient.setQueryData(queryKey, (oldData: any) => {
-    if (!oldData) return oldData;
-    return {
-      pages: oldData.pages.slice(0, 1),
-      pageParams: oldData.pageParams.slice(0, 1),
-    };
-  });
+  // 只裁剪页数组本身,不触碰页内容,因此元素类型用 unknown 即可。
+  queryClient.setQueryData<InfiniteData<unknown, unknown>>(
+    queryKey,
+    (oldData) => {
+      if (!oldData) return oldData;
+      return {
+        pages: oldData.pages.slice(0, 1),
+        pageParams: oldData.pageParams.slice(0, 1),
+      };
+    },
+  );
   return refetch();
 }


### PR DESCRIPTION
## 背景

`npx biome check` 当前报 41 errors + 339 warnings。本 PR 只处理其中**与代码风格无关、修法唯一或接近唯一**的部分,不触碰需要判断作者意图的诊断。

分类依据是"这条诊断有没有主观选择空间":

| 规则 | 数量 | 本 PR 是否处理 | 理由 |
| --- | --- | --- | --- |
| `noUnknownAtRules` | 3 err | ✅ | 配置问题,不是代码问题 |
| `noUnusedVariables` | 6 warn | ✅ | 删除,唯一解 |
| `noChildrenProp` | 1 err | ✅ | prop 重命名,唯一解 |
| `noDangerouslySetInnerHtml` | 2 err | ✅ | 唯一解是豁免,不是改代码 |
| `noArrayIndexKey` | 13 err | ✅ | 逐个核过数据来源后处理 |
| 两个"类型黑洞"文件 | 8 个 `any` | ✅ | 影响面最大的类型问题 |
| `useExhaustiveDependencies` | 22 err | ❌ | 每处都要判断是否"故意只在挂载时跑" |
| 其余 `any` | 319 warn | ❌ | 需要补知乎 API 类型,是工程不是清理 |

## 设计要点

### 类型严格性:数量不等于紧急程度

333 个 `noExplicitAny` 里绝大多数是局部放宽(`(item: any) => item.id`),只污染一个表达式。真正紧急的是两个**会传染的**文件:

- `hooks/useZhihuInfiniteQuery.ts` 收 `options: any`、返回 `as any) as any`,四个调用页面(answer/question/topic/user-likes)解构出的 `data`、`fetchNextPage`、`hasNextPage`、`refetch` 全部是 `any`。泛型参数写成 `_TData` 说明作者本来想做泛型、中途放弃了。
- `utils/query.ts` 的 `queryKey: any[]` + `(oldData: any)` 同样穿透到 8 个调用文件。

改 8 个 `any`,12 个文件恢复类型检查。两处都改用 TanStack 自己的泛型,`getNextPageParam` 的运行逻辑一字未改。

**打开类型后立刻捞出一个真实缺陷**:`app/answer/[id].tsx` 从来没传 `initialPageParam`,而 v5 要求必填。之前 `options: any` 把它藏住了。运行时靠 `queryFn` 的 `{ pageParam = 0 }` 默认值兜住,请求参数一直是对的,只有 `data.pageParams[0]` 存的是 `undefined` 而非 `0`。已显式补上。

### `T[] | any[]` 不是放宽类型,是抹掉类型

`types/zhihu.ts` 有三个字段声明成 `ZhihuBadge[] | any[]` 这种形式。`any[]` 那一支接受任何值,声明的形状既约束不了赋值也进不了推断,等于左半边白写。去掉 `any[]` 支即可。全项目无消费点的 `sources` 一并收敛为 `unknown[]`,保留"是个数组"而禁止未检查访问。

### `noArrayIndexKey`:核过数据来源,只有 1 处该换

13 处逐个追到数据来源后,**只有 `app/search.tsx` 的搜索历史该换**——它是唯一一个会从中间删元素的列表(`removeHistory`),而 `addHistory` 显式去重保证了查询串唯一,`key={item}` 现成可用。

其余 12 处的数组都由一段内容同步派生,不增删不重排,index 在列表存续期间稳定。其中 4 处换成"看起来更稳定"的 key 反而更糟:

- `FeedExcerpt` 的 link_card 经 `l.url || ''` 映射,多张缺 url 的卡片会塌成同一个空串
- `CommentContent` 用正则提图且不去重,同一条评论可以重复引用同一张图——它已经在用复合 key
- `ZhihuContent` 的想法正文把文本/图片/链接卡片混在一个 map 里,`PinContentItem` 没有 id
- 渐变色条的色值本来就重复

这些改为逐条 `biome-ignore` 并写明具体理由,而不是让 13 个 error 一直挂着,规则继续对下一个真正需要稳定 key 的列表生效。

### 删除的都是"无 selector 的订阅"

6 处 `noUnusedVariables` 恰好每个都来自订阅型 hook,删掉顺带去掉它们造成的 re-render:`useWindowDimensions`、不带 selector 因而订阅整个 store 的 `useProgressStore()` / `useSettingsStore()`、以及 `AnswerDetailView` 里会构建两个 mutation 加三个 store 订阅的 `useCollectionAction()`(该视图自己 import 了 `fastCollectAnswer` / `removeFromCollection` 走独立实现,这个 hook 是重构残留)。`ZhihuContent` 那处影响最大——它在 `IMG_Renderer` 里,正文每张图跑一次。

## 修改内容(按 commit)

1. **chore(biome): recognize tailwind at-rules instead of erroring on them** — 用规则的 `ignore` 选项白名单 tailwind 指令,而不是关掉规则,拼错的 at-rule 仍会被抓
2. **refactor: drop unused hook calls and their subscriptions** — 6 处死绑定连同其订阅
3. **refactor(topic): rename TopicStructureView's children prop to childTopics** — 该 prop 传的是子话题数据,占用 `children` 这个保留名意味着嵌套内容会静默覆盖它
4. **chore(lint): document the two intentional dangerouslySetInnerHTML uses** — `+html.tsx` 注入同文件常量(Expo Router 标准 shell);`MathView` 注入 `katex.renderToString` 结果,该 API 默认 `trust: false`,拒绝渲染 `\href` / `\url` / `\includegraphics` 等可产出 URL 或标记的命令
5. **fix(types): stop cancelling the badge types with `| any[]`**
6. **refactor(query): give the shared infinite-query helpers real types** — 含 `initialPageParam` 缺失的修复
7. **fix(search): key search history chips by the query itself**
8. **chore(lint): record why the remaining index keys are correct**

## 验证

- `npx tsc --noEmit`:0 错误
- `npx biome check`:**41 errors + 339 warnings → 22 errors + 319 warnings**,剩余项全部是本 PR 明确不处理的 `useExhaustiveDependencies`(22)与 `noExplicitAny`(319)
- 未做真机验证。改动只有三类:构建工具配置(零运行时)、删除死绑定(均为纯订阅型 hook,无 effect 无副作用)、类型标注(编译后消失)。唯一有实质运行时差异的是补上的 `initialPageParam: 0`,如上所述与既有默认值等价。如果维护者认为仍需上机确认,我可以补。

## 未包含

- **`useExhaustiveDependencies`(22 errors)**:补依赖可能引入无限循环,加豁免又需要逐个确认"是否故意只在挂载时执行"。这跟代码风格无关,跟作者意图强相关,建议单独一轮、逐个过。
- **其余 319 个 `noExplicitAny`**:主要是 `(item: any) => ...` 形态的 API 响应映射,真正的解法是给知乎接口补类型定义。"定义到多细"、"要不要上运行时校验"都是设计选择,不适合夹在清理 PR 里。
- `components/UserCard.tsx` 的 `user: any` 未动:该组件消费的 `follower_count` 不在 `ZhihuAuthor` 里,收敛它需要先定类型边界。本 PR 只把 badge 回调参数标注上,不改 `user` 的签名。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
