### PR TITLE
Add content filtering features and settings for FeedItem

### DIFF
--- a/api/zhihu/feed.ts
+++ b/api/zhihu/feed.ts
@@ -34,6 +34,25 @@ export interface FeedItem {
   rank?: number;
   hotValue?: string;
   titleString?: string;
+  // —— 本地过滤所需的结构化信号（实测推荐流可用字段，见 utils/feedFilter.ts）——
+  /** `answer_type === 'PAID'` 或 `paid_info != null` 即知乎盐选付费内容 */
+  answerType?: string;
+  /** 推广/利益声明标记，话题流返回、推荐流通常不返回 */
+  isLabeled?: boolean;
+  /** author.is_org —— 机构号 */
+  isOrgAuthor?: boolean;
+  /** author.is_advertiser —— 广告主 */
+  isAdvertiser?: boolean;
+  /** author.is_following —— 当前用户是否关注作者（质量规则的内建豁免依据） */
+  isFollowingAuthor?: boolean;
+  /** relationship.upvoted_followee_ids 非空 —— 我关注的人赞过 */
+  upvotedByFollowee?: boolean;
+  /** question.bound_topic_ids，为二期话题屏蔽预留 */
+  boundTopicIds?: number[];
+  /** question.answer_count，问题类型质量判定用 */
+  answerCount?: number;
+  /** question.follower_count，问题类型质量判定用 */
+  followerCount?: number;
 }
 
 export interface RawFeedTarget {
@@ -49,6 +68,12 @@ export interface RawFeedTarget {
   comment_count?: number;
   favlists_count?: number;
   favorite_count?: number;
+  /** 回答类型：`NORMAL` / `PAID`；`PAID` 即知乎盐选付费内容 */
+  answer_type?: string;
+  /** 盐选付费信息，与 `answer_type === 'PAID'` 取或作为兜底信号 */
+  paid_info?: unknown;
+  /** 推广/利益声明标记（话题流返回，推荐流通常不返回） */
+  is_labeled?: boolean;
   reaction?: {
     relation?: {
       liked?: boolean;
@@ -61,6 +86,8 @@ export interface RawFeedTarget {
   };
   relationship?: {
     voting?: number;
+    /** 我关注的人赞过该内容的作者 ID 列表（推荐流可返回） */
+    upvoted_followee_ids?: unknown[];
   };
   author?: {
     id: string;
@@ -68,10 +95,22 @@ export interface RawFeedTarget {
     avatar_url: string;
     headline?: string;
     url_token?: string;
+    /** 机构号标记 */
+    is_org?: boolean;
+    /** 广告主标记 */
+    is_advertiser?: boolean;
+    /** 当前用户是否关注该作者 */
+    is_following?: boolean;
   };
   question?: {
     id: string | number;
     title: string;
+    /** 问题绑定的顶级话题 ID 列表 */
+    bound_topic_ids?: number[];
+    /** 问题下的回答数 */
+    answer_count?: number;
+    /** 问题关注数 */
+    follower_count?: number;
   };
   topics?: Array<{
     id: string;

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -90,10 +90,10 @@ const TABS = [
 type TabType = (typeof TABS)[number];
 type FeedListItem = FeedItem | HotItem | CollapsedGroup;
 
-// 自动补页阈值：隐藏模式下被过滤项不占行，列表偏短时自动续页避免空白。
-// 触顶后在列表底部显示提示，不静默停止。
+// 隐藏模式下被过滤项不占行；列表短于该阈值且已无更多页时，footer 给出
+// 一句诚实的提示，避免用户以为加载卡住。折叠模式下过滤项仍占一行，
+// 不会触发该阈值。
 const MIN_RENDERABLE_ITEMS = 8;
-const MAX_AUTO_FETCH_ROUNDS = 3;
 
 export default function HomeScreen() {
   const { width: windowWidth } = useWindowDimensions();
@@ -797,8 +797,6 @@ const FeedList = React.forwardRef<
         return next;
       });
     }, []);
-    // 自动补页：隐藏模式下被过滤项不占行，列表偏短时自动续页避免空白
-    const [autoFetchRounds, setAutoFetchRounds] = useState(0);
     const [recentExposureKeys, setRecentExposureKeys] =
       useState<Set<string> | null>(() =>
         localDedupEnabled ? null : new Set(),
@@ -970,9 +968,8 @@ const FeedList = React.forwardRef<
     const handleRefresh = useCallback(async () => {
       setIsRefreshing(true);
       onRefreshStateChange?.(true);
-      // 刷新即重置折叠展开状态与自动补页计数
+      // 刷新即重置折叠展开状态（计划要求展开不持久化）
       setExpandedCollapsedKeys(new Set());
-      setAutoFetchRounds(0);
       try {
         if (localDedupEnabled && exposureContext) {
           try {
@@ -1092,17 +1089,10 @@ const FeedList = React.forwardRef<
           return `feed-${key || index}`;
         }}
         onEndReached={() => {
-          if (!hasNextPage || isFetchingNextPage) return;
-          // 隐藏模式下被过滤项不占行，列表偏短时自动续页避免空白；
-          // 触顶 MAX_AUTO_FETCH_ROUNDS 次后不再静默续页，由 footer 提示
-          if (
-            filterEnabled &&
-            flattenedData.length < MIN_RENDERABLE_ITEMS &&
-            autoFetchRounds < MAX_AUTO_FETCH_ROUNDS
-          ) {
-            setAutoFetchRounds((n) => n + 1);
-          }
-          fetchNextPage();
+          // 只要有下一页就继续追加。隐藏模式被过滤项不占行，列表自然偏短，
+          // 这里依靠 hasNextPage 持续续页即可；列表过短且已到底时由 footer
+          // 给出一句诚实的提示，避免用户以为加载卡住。
+          if (hasNextPage && !isFetchingNextPage) fetchNextPage();
         }}
         onEndReachedThreshold={0.5}
         onViewableItemsChanged={onViewableItemsChanged}
@@ -1124,7 +1114,7 @@ const FeedList = React.forwardRef<
           paddingTop: insets.top + 70,
           paddingBottom: 120,
         }}
-        renderItem={({ item }: { item: any }) => {
+        renderItem={({ item }: { item: FeedListItem }) => {
           if (isCollapsedGroup(item)) {
             const expanded = expandedCollapsedKeys.has(item.groupKey);
             const showReason = filterMode === 'collapse' && filterShowReason;
@@ -1151,9 +1141,11 @@ const FeedList = React.forwardRef<
             );
           }
           return tab === 'hot' ? (
-            <HotCard item={item} />
+            // tab 在该 FeedList 实例生命周期内不变，是可靠的运行时判别：
+            // hot tab 的 data 只含 HotItem，其余 tab 只含 FeedItem（折叠行已在上层排除）。
+            <HotCard item={item as HotItem} />
           ) : (
-            <FeedCard item={item} tab={tab} />
+            <FeedCard item={item as FeedItem} tab={tab} />
           );
         }}
         ListHeaderComponent={tab === 'following' ? <RecentMoments /> : null}
@@ -1162,7 +1154,7 @@ const FeedList = React.forwardRef<
             <ActivityIndicator style={{ margin: 20 }} />
           ) : filterEnabled &&
             !hasNextPage &&
-            autoFetchRounds >= MAX_AUTO_FETCH_ROUNDS ? (
+            flattenedData.length <= MIN_RENDERABLE_ITEMS ? (
             <Text
               type="secondary"
               style={{ textAlign: 'center', margin: 20, fontSize: 12 }}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -57,6 +57,13 @@ import { useAuthStore } from '@/store/useAuthStore';
 import { type TabKey, useSettingsStore } from '@/store/useSettingsStore';
 import { supportsLocalFeedDedup } from '@/utils/feedDedup';
 import {
+  applyFeedFilter,
+  type CollapsedGroup,
+  type FeedFilterRules,
+  isCollapsedGroup,
+  supportsLocalFeedFilter,
+} from '@/utils/feedFilter';
+import {
   type FeedContentIdentity,
   getFeedContentIdentity,
   getFeedContentKey,
@@ -81,7 +88,12 @@ const TABS = [
   'profile',
 ] as const;
 type TabType = (typeof TABS)[number];
-type FeedListItem = FeedItem | HotItem;
+type FeedListItem = FeedItem | HotItem | CollapsedGroup;
+
+// 自动补页阈值：隐藏模式下被过滤项不占行，列表偏短时自动续页避免空白。
+// 触顶后在列表底部显示提示，不静默停止。
+const MIN_RENDERABLE_ITEMS = 8;
+const MAX_AUTO_FETCH_ROUNDS = 3;
 
 export default function HomeScreen() {
   const { width: windowWidth } = useWindowDimensions();
@@ -700,8 +712,24 @@ const FeedList = React.forwardRef<
   ) => {
     const queryClient = useQueryClient();
     const { cookies, me } = useAuthStore();
-    const { enableLocalFeedDedup, enableFeedCacheOnLaunch } =
-      useSettingsStore();
+    const {
+      enableLocalFeedDedup,
+      enableFeedCacheOnLaunch,
+      enableLocalFeedFilter,
+      filterMode,
+      filterShowReason,
+      filterBlockPaid,
+      filterBlockAdPlatform,
+      filterBlockZhihuSchool,
+      filterBlockWeChat,
+      filterBlockLabeled,
+      filterBlockOrgAuthor,
+      filterBlockAdvertiser,
+      filterEnableQuality,
+      filterQualityLevel,
+      filterKeepFollowing,
+      filterKeepUpvotedByFollowee,
+    } = useSettingsStore();
     const _colorScheme = useColorScheme();
     const tintColor = useThemeColor({}, 'primary');
     const [isRefreshing, setIsRefreshing] = useState(false);
@@ -726,6 +754,51 @@ const FeedList = React.forwardRef<
       if (!localAccountKey) return null;
       return { accountKey: localAccountKey, feedType: tab };
     }, [enableFeedCacheOnLaunch, localAccountKey, tab]);
+
+    const filterRules = useMemo<FeedFilterRules>(
+      () => ({
+        blockPaid: filterBlockPaid,
+        blockAdPlatform: filterBlockAdPlatform,
+        blockZhihuSchool: filterBlockZhihuSchool,
+        blockWeChat: filterBlockWeChat,
+        blockLabeled: filterBlockLabeled,
+        blockOrgAuthor: filterBlockOrgAuthor,
+        blockAdvertiser: filterBlockAdvertiser,
+        enableQuality: filterEnableQuality,
+        qualityLevel: filterQualityLevel,
+        keepFollowing: filterKeepFollowing,
+        keepUpvotedByFollowee: filterKeepUpvotedByFollowee,
+      }),
+      [
+        filterBlockPaid,
+        filterBlockAdPlatform,
+        filterBlockZhihuSchool,
+        filterBlockWeChat,
+        filterBlockLabeled,
+        filterBlockOrgAuthor,
+        filterBlockAdvertiser,
+        filterEnableQuality,
+        filterQualityLevel,
+        filterKeepFollowing,
+        filterKeepUpvotedByFollowee,
+      ],
+    );
+    // 本地过滤仅作用于推荐流
+    const filterEnabled = enableLocalFeedFilter && supportsLocalFeedFilter(tab);
+    // 折叠组展开状态：刷新即重置，不持久化
+    const [expandedCollapsedKeys, setExpandedCollapsedKeys] = useState<
+      Set<string>
+    >(new Set());
+    const toggleCollapsed = useCallback((groupKey: string) => {
+      setExpandedCollapsedKeys((prev) => {
+        const next = new Set(prev);
+        if (next.has(groupKey)) next.delete(groupKey);
+        else next.add(groupKey);
+        return next;
+      });
+    }, []);
+    // 自动补页：隐藏模式下被过滤项不占行，列表偏短时自动续页避免空白
+    const [autoFetchRounds, setAutoFetchRounds] = useState(0);
     const [recentExposureKeys, setRecentExposureKeys] =
       useState<Set<string> | null>(() =>
         localDedupEnabled ? null : new Set(),
@@ -818,7 +891,9 @@ const FeedList = React.forwardRef<
         if (!enabled || !context) return;
 
         const identities = viewableItems
-          .map((viewable) => getFeedContentIdentity(viewable.item))
+          .map((viewable) => viewable.item)
+          .filter((item): item is FeedItem | HotItem => !isCollapsedGroup(item))
+          .map((item) => getFeedContentIdentity(item))
           .filter(
             (identity): identity is FeedContentIdentity => identity !== null,
           );
@@ -895,6 +970,9 @@ const FeedList = React.forwardRef<
     const handleRefresh = useCallback(async () => {
       setIsRefreshing(true);
       onRefreshStateChange?.(true);
+      // 刷新即重置折叠展开状态与自动补页计数
+      setExpandedCollapsedKeys(new Set());
+      setAutoFetchRounds(0);
       try {
         if (localDedupEnabled && exposureContext) {
           try {
@@ -930,9 +1008,16 @@ const FeedList = React.forwardRef<
     const flattenedData = useMemo(() => {
       const all = data?.pages.flatMap((page) => page.items) ?? [];
       const seen = new Set<string>();
-      return all.filter((item) => {
+      const deduped: FeedListItem[] = [];
+      for (const item of all) {
+        // 启动缓存与解析均只产出 FeedItem / HotItem，折叠行不会从源头进入；
+        // 这里仅做类型收窄，避免 CollapsedGroup 误传入 identity 函数。
+        if (isCollapsedGroup(item)) {
+          deduped.push(item);
+          continue;
+        }
         const inMemoryKey = getInMemoryFeedKey(item);
-        if (!inMemoryKey || seen.has(inMemoryKey)) return false;
+        if (!inMemoryKey || seen.has(inMemoryKey)) continue;
         seen.add(inMemoryKey);
 
         const persistentKey = getFeedContentKey(item);
@@ -941,11 +1026,43 @@ const FeedList = React.forwardRef<
           persistentKey &&
           recentExposureKeys?.has(persistentKey)
         ) {
-          return false;
+          continue;
         }
-        return true;
-      });
-    }, [data, localDedupEnabled, recentExposureKeys]);
+        deduped.push(item);
+      }
+
+      // 本地过滤仅作用于推荐流。Recommend tab 下 deduped 全为 FeedItem。
+      if (filterEnabled) {
+        const filtered = applyFeedFilter(
+          deduped as FeedItem[],
+          filterRules,
+          filterMode,
+        );
+        const out: FeedListItem[] = [];
+        for (const item of filtered) {
+          if (
+            isCollapsedGroup(item) &&
+            expandedCollapsedKeys.has(item.groupKey)
+          ) {
+            // 已展开：保留折叠行（变「已展开」态）并把内容平铺回列表
+            out.push(item);
+            for (const sub of item.items) out.push(sub);
+          } else {
+            out.push(item);
+          }
+        }
+        return out;
+      }
+      return deduped;
+    }, [
+      data,
+      localDedupEnabled,
+      recentExposureKeys,
+      filterEnabled,
+      filterRules,
+      filterMode,
+      expandedCollapsedKeys,
+    ]);
 
     const flashListRef = useRef<FlashListRef<FeedListItem>>(null);
 
@@ -970,12 +1087,23 @@ const FeedList = React.forwardRef<
         showsVerticalScrollIndicator={false}
         data={flattenedData}
         keyExtractor={(item, index) => {
+          if (isCollapsedGroup(item)) return `collapsed-${item.groupKey}`;
           const key = getInMemoryFeedKey(item);
           return `feed-${key || index}`;
         }}
-        onEndReached={() =>
-          hasNextPage && !isFetchingNextPage && fetchNextPage()
-        }
+        onEndReached={() => {
+          if (!hasNextPage || isFetchingNextPage) return;
+          // 隐藏模式下被过滤项不占行，列表偏短时自动续页避免空白；
+          // 触顶 MAX_AUTO_FETCH_ROUNDS 次后不再静默续页，由 footer 提示
+          if (
+            filterEnabled &&
+            flattenedData.length < MIN_RENDERABLE_ITEMS &&
+            autoFetchRounds < MAX_AUTO_FETCH_ROUNDS
+          ) {
+            setAutoFetchRounds((n) => n + 1);
+          }
+          fetchNextPage();
+        }}
         onEndReachedThreshold={0.5}
         onViewableItemsChanged={onViewableItemsChanged}
         viewabilityConfig={viewabilityConfig}
@@ -996,17 +1124,51 @@ const FeedList = React.forwardRef<
           paddingTop: insets.top + 70,
           paddingBottom: 120,
         }}
-        renderItem={({ item }: { item: any }) =>
-          tab === 'hot' ? (
+        renderItem={({ item }: { item: any }) => {
+          if (isCollapsedGroup(item)) {
+            const expanded = expandedCollapsedKeys.has(item.groupKey);
+            const showReason = filterMode === 'collapse' && filterShowReason;
+            return (
+              <Pressable
+                onPress={() => toggleCollapsed(item.groupKey)}
+                className="mx-2 my-1 flex-row items-center justify-between rounded-xl px-4 py-3"
+                style={{ backgroundColor: tintColor + '14' }}
+              >
+                <Text type="secondary">
+                  {expanded
+                    ? `已展开 ${item.items.length} 条`
+                    : `已折叠 ${item.items.length} 条`}
+                  {showReason && !expanded && item.reasons.length > 0
+                    ? ` · ${item.reasons.join('、')}`
+                    : ''}
+                </Text>
+                <Ionicons
+                  name={expanded ? 'chevron-up' : 'chevron-down'}
+                  size={16}
+                  color={tintColor}
+                />
+              </Pressable>
+            );
+          }
+          return tab === 'hot' ? (
             <HotCard item={item} />
           ) : (
             <FeedCard item={item} tab={tab} />
-          )
-        }
+          );
+        }}
         ListHeaderComponent={tab === 'following' ? <RecentMoments /> : null}
         ListFooterComponent={
           isFetchingNextPage ? (
             <ActivityIndicator style={{ margin: 20 }} />
+          ) : filterEnabled &&
+            !hasNextPage &&
+            autoFetchRounds >= MAX_AUTO_FETCH_ROUNDS ? (
+            <Text
+              type="secondary"
+              style={{ textAlign: 'center', margin: 20, fontSize: 12 }}
+            >
+              过滤后内容偏少，已无更多可加载
+            </Text>
           ) : null
         }
         ListEmptyComponent={
@@ -1114,6 +1276,26 @@ function parseRecommendData(item: RawFeedItem): FeedItem | null {
     voted: target.relationship?.voting || 0,
     type: appType,
     topics: target.topics?.map((t: any) => ({ id: t.id, name: t.name })) || [],
+    // 本地过滤信号：实测推荐流可用字段（详见 utils/feedFilter.ts）
+    // 盐选双信号取或：answer_type === 'PAID' 或 paid_info != null
+    answerType:
+      target.answer_type === 'PAID' || target.paid_info != null
+        ? 'PAID'
+        : target.answer_type,
+    isLabeled: Boolean(target.is_labeled),
+    isOrgAuthor: Boolean(target.author?.is_org),
+    isAdvertiser: Boolean(target.author?.is_advertiser),
+    isFollowingAuthor: Boolean(target.author?.is_following),
+    upvotedByFollowee:
+      (target.relationship?.upvoted_followee_ids?.length ?? 0) > 0,
+    boundTopicIds: target.question?.bound_topic_ids,
+    // question 类型 target 自身即 question，答案/文章则从嵌套 question 读取
+    answerCount:
+      type === 'question' ? target.answer_count : target.question?.answer_count,
+    followerCount:
+      type === 'question'
+        ? target.follower_count
+        : target.question?.follower_count,
   };
 }
 

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -340,6 +340,12 @@ export default function ProfileScreen() {
           color={accentColor}
           onPress={() => router.push('/settings/appearance' as any)}
         />
+        <MenuItem
+          icon="filter-outline"
+          title="过滤与推荐"
+          color={accentColor}
+          onPress={() => router.push('/settings/filter' as any)}
+        />
 
         <MenuItem
           icon="notifications-outline"

--- a/app/settings/appearance.tsx
+++ b/app/settings/appearance.tsx
@@ -16,12 +16,11 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BouncyButton } from '@/components/BouncyButton';
+import { Section, SettingItem } from '@/components/SettingItem';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
-import { feedExposureRepository } from '@/storage/feedExposureRepository';
 import { type TabKey, useSettingsStore } from '@/store/useSettingsStore';
-import { showToast } from '@/utils/toast';
 
 // 开启 Android 下的 LayoutAnimation
 if (
@@ -61,8 +60,6 @@ export default function AppearanceSettings() {
     useWebView,
     enablePrivateMessaging,
     enableBrowseHistory,
-    enableLocalFeedDedup,
-    enableFeedCacheOnLaunch,
     pressOpacity,
     pressScale,
     androidFeedbackType,
@@ -569,65 +566,6 @@ export default function AppearanceSettings() {
               trackColor={{ true: tintColor }}
             />
           </SettingItem>
-          <SettingItem
-            label="本地 Feed 去重"
-            icon="layers-outline"
-            colorScheme={colorScheme}
-          >
-            <Switch
-              value={enableLocalFeedDedup}
-              onValueChange={(val) =>
-                updateSettings({ enableLocalFeedDedup: val })
-              }
-              trackColor={{ true: tintColor }}
-            />
-          </SettingItem>
-          <SettingItem
-            label="启动时保留推荐流"
-            icon="bookmark-outline"
-            colorScheme={colorScheme}
-          >
-            <Switch
-              value={enableFeedCacheOnLaunch}
-              onValueChange={(val) =>
-                updateSettings({ enableFeedCacheOnLaunch: val })
-              }
-              trackColor={{ true: tintColor }}
-            />
-          </SettingItem>
-          <SettingItem
-            label="清除本地去重记录"
-            icon="trash-bin-outline"
-            colorScheme={colorScheme}
-          >
-            <Pressable
-              onPress={() => {
-                Alert.alert(
-                  '清除本地去重记录',
-                  '清除后，近期看过的推荐内容可能再次出现。',
-                  [
-                    { text: '取消', style: 'cancel' },
-                    {
-                      text: '清除',
-                      style: 'destructive',
-                      onPress: async () => {
-                        try {
-                          await feedExposureRepository.clearAll();
-                          showToast('本地去重记录已清除');
-                        } catch (error) {
-                          console.error('清除本地去重记录失败', error);
-                          showToast('清除失败，请稍后重试');
-                        }
-                      },
-                    },
-                  ],
-                );
-              }}
-              className="px-3 py-1.5"
-            >
-              <Text style={{ color: Colors[colorScheme].danger }}>清除</Text>
-            </Pressable>
-          </SettingItem>
         </Section>
 
         <Pressable
@@ -652,84 +590,6 @@ export default function AppearanceSettings() {
           </Text>
         </Pressable>
       </ScrollView>
-    </RNView>
-  );
-}
-
-// ================= UI Components =================
-
-function Section({
-  title,
-  children,
-  colorScheme,
-}: {
-  title: string;
-  children: React.ReactNode;
-  colorScheme: 'light' | 'dark';
-}) {
-  const isDark = colorScheme === 'dark';
-  const cardBg = isDark ? '#1C1C1E' : '#FFFFFF';
-  const dividerColor = isDark ? '#38383A' : '#E5E5EA';
-
-  // 为 Section 内部元素自动添加底部分割线
-  const childArray = React.Children.toArray(children).filter(Boolean);
-
-  return (
-    <RNView style={styles.section}>
-      <Text style={styles.sectionTitle} type="secondary">
-        {title}
-      </Text>
-      <RNView style={[styles.sectionContent, { backgroundColor: cardBg }]}>
-        {childArray.map((child, index) => {
-          const isLast = index === childArray.length - 1;
-          return (
-            <RNView
-              // biome-ignore lint/suspicious/noArrayIndexKey: childArray 来自 React.Children,子元素在调用处的 JSX 里逐个写死,数量与顺序在编译期就固定了。
-              key={index}
-            >
-              {child}
-              {!isLast && (
-                <RNView
-                  style={[styles.divider, { backgroundColor: dividerColor }]}
-                />
-              )}
-            </RNView>
-          );
-        })}
-      </RNView>
-    </RNView>
-  );
-}
-
-function SettingItem({
-  label,
-  icon,
-  children,
-  colorScheme,
-}: {
-  label: string;
-  icon?: keyof typeof Ionicons.glyphMap;
-  children: React.ReactNode;
-  colorScheme: 'light' | 'dark';
-}) {
-  return (
-    <RNView style={styles.settingItem}>
-      <RNView style={styles.settingLabelContainer}>
-        {icon && (
-          <RNView
-            style={[
-              styles.iconWrapper,
-              {
-                backgroundColor: colorScheme === 'dark' ? '#2C2C2E' : '#F2F2F7',
-              },
-            ]}
-          >
-            <Ionicons name={icon} size={16} color={Colors[colorScheme].text} />
-          </RNView>
-        )}
-        <Text style={styles.settingLabel}>{label}</Text>
-      </RNView>
-      {children}
     </RNView>
   );
 }
@@ -1061,43 +921,6 @@ function ColorPickerSection({ primaryColor, onColorChange }: any) {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  section: { marginBottom: 28 },
-  sectionTitle: {
-    fontSize: 13,
-    marginBottom: 8,
-    marginLeft: 16,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  sectionContent: {
-    borderRadius: 12,
-    overflow: 'hidden',
-  },
-  divider: {
-    height: StyleSheet.hairlineWidth,
-    marginLeft: 48, // 避开 Icon 区域的分割线
-  },
-  settingItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingVertical: 14,
-    paddingHorizontal: 16,
-    minHeight: 52,
-  },
-  settingLabelContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-  },
-  iconWrapper: {
-    width: 28,
-    height: 28,
-    borderRadius: 6,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  settingLabel: { fontSize: 16 },
   row: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/app/settings/filter.tsx
+++ b/app/settings/filter.tsx
@@ -1,0 +1,537 @@
+import type { Ionicons } from '@expo/vector-icons';
+import { useQueryClient } from '@tanstack/react-query';
+import { Stack } from 'expo-router';
+import { useMemo } from 'react';
+import {
+  Alert,
+  Platform,
+  Pressable,
+  View as RNView,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  UIManager,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { FeedItem } from '@/api/zhihu';
+import {
+  Section,
+  SettingItem,
+  settingsChipStyles as s,
+} from '@/components/SettingItem';
+import { Text, useThemeColor } from '@/components/Themed';
+import { useColorScheme } from '@/components/useColorScheme';
+import Colors from '@/constants/Colors';
+import { feedExposureRepository } from '@/storage/feedExposureRepository';
+import { useSettingsStore } from '@/store/useSettingsStore';
+import { computeFilterStats } from '@/utils/feedFilter';
+import { showToast } from '@/utils/toast';
+
+// LayoutAnimation 在 Android 上需显式开启
+if (
+  Platform.OS === 'android' &&
+  UIManager.setLayoutAnimationEnabledExperimental
+) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+const QUALITY_LEVELS: {
+  key: 'loose' | 'standard' | 'strict';
+  label: string;
+}[] = [
+  { key: 'loose', label: '宽松' },
+  { key: 'standard', label: '标准' },
+  { key: 'strict', label: '严格' },
+];
+
+export default function FilterSettings() {
+  const insets = useSafeAreaInsets();
+  const colorScheme = useColorScheme() ?? 'light';
+  const queryClient = useQueryClient();
+  const tintColor = useThemeColor({}, 'primary');
+  const isDark = colorScheme === 'dark';
+
+  const {
+    enableLocalFeedFilter,
+    filterMode,
+    filterShowReason,
+    filterBlockPaid,
+    filterBlockAdPlatform,
+    filterBlockZhihuSchool,
+    filterBlockWeChat,
+    filterBlockLabeled,
+    filterBlockOrgAuthor,
+    filterBlockAdvertiser,
+    filterEnableQuality,
+    filterQualityLevel,
+    filterKeepFollowing,
+    filterKeepUpvotedByFollowee,
+    enableLocalFeedDedup,
+    enableFeedCacheOnLaunch,
+    updateSettings,
+  } = useSettingsStore();
+
+  // 实时效果条：读取已缓存的推荐流数据，本地跑一遍规则计算过滤率，
+  // 不发请求。queryClient key 与 index.tsx 的 useInfiniteQuery 一致，
+  // 这里用前缀匹配覆盖所有账号，filter 到 recommend tab。
+  const stats = useMemo(() => {
+    if (!enableLocalFeedFilter) return null;
+    // react-query 的 getQueriesData 返回 unknown，这里收窄成 useInfiniteQuery
+    // 的最小可见结构——只读页面里的元素数组，不假设其余字段。
+    interface FeedCachePage {
+      items?: unknown[];
+    }
+    interface FeedCacheData {
+      pages?: FeedCachePage[];
+    }
+    const queries = queryClient.getQueriesData<FeedCacheData>({
+      queryKey: ['zhihu-feed'],
+    });
+    const feedItems: unknown[] = [];
+    for (const [key, data] of queries) {
+      if (!Array.isArray(key) || key[2] !== 'recommend') continue;
+      const items = data?.pages?.flatMap((p) => p.items ?? []) ?? [];
+      for (const it of items) feedItems.push(it);
+    }
+    if (feedItems.length === 0) return null;
+    return computeFilterStats(feedItems as FeedItem[], {
+      blockPaid: filterBlockPaid,
+      blockAdPlatform: filterBlockAdPlatform,
+      blockZhihuSchool: filterBlockZhihuSchool,
+      blockWeChat: filterBlockWeChat,
+      blockLabeled: filterBlockLabeled,
+      blockOrgAuthor: filterBlockOrgAuthor,
+      blockAdvertiser: filterBlockAdvertiser,
+      enableQuality: filterEnableQuality,
+      qualityLevel: filterQualityLevel,
+      keepFollowing: filterKeepFollowing,
+      keepUpvotedByFollowee: filterKeepUpvotedByFollowee,
+    });
+  }, [
+    enableLocalFeedFilter,
+    queryClient,
+    filterBlockPaid,
+    filterBlockAdPlatform,
+    filterBlockZhihuSchool,
+    filterBlockWeChat,
+    filterBlockLabeled,
+    filterBlockOrgAuthor,
+    filterBlockAdvertiser,
+    filterEnableQuality,
+    filterQualityLevel,
+    filterKeepFollowing,
+    filterKeepUpvotedByFollowee,
+  ]);
+
+  // 警告阈值随显示模式分档：隐藏模式 >50%、折叠模式 >70% 提示。
+  // 过滤率过高会让自动补页持续触顶，推荐流频繁空白。
+  const warnThreshold = filterMode === 'hide' ? 0.5 : 0.7;
+  const warn = stats != null && stats.rate > warnThreshold;
+
+  const switchProps = {
+    trackColor: { true: tintColor },
+  };
+
+  return (
+    <RNView
+      style={[
+        styles.container,
+        { backgroundColor: isDark ? '#000000' : '#F2F2F6' },
+      ]}
+    >
+      <Stack.Screen
+        options={{ title: '过滤与推荐', headerShadowVisible: false }}
+      />
+
+      <ScrollView
+        contentContainerStyle={{
+          padding: 16,
+          paddingBottom: insets.bottom + 40,
+        }}
+      >
+        {/* 实时效果条 */}
+        {enableLocalFeedFilter && stats != null && (
+          <RNView
+            style={[
+              styles.statsCard,
+              {
+                backgroundColor: isDark ? '#1C1C1E' : '#FFFFFF',
+                borderColor: warn ? Colors[colorScheme].warning : 'transparent',
+              },
+            ]}
+          >
+            <Text style={styles.statsTitle}>
+              最近 {stats.total} 条内容将过滤 {stats.filtered} 条 ·{' '}
+              {(stats.rate * 100).toFixed(0)}%
+            </Text>
+            <RNView
+              style={[
+                styles.statsBarTrack,
+                { backgroundColor: isDark ? '#2C2C2E' : '#E5E5EA' },
+              ]}
+            >
+              <RNView
+                style={{
+                  width: `${Math.min(100, stats.rate * 100)}%`,
+                  height: '100%',
+                  borderRadius: 3,
+                  backgroundColor: warn
+                    ? Colors[colorScheme].warning
+                    : tintColor,
+                }}
+              />
+            </RNView>
+            {warn && (
+              <Text
+                style={{
+                  color: Colors[colorScheme].warning,
+                  fontSize: 12,
+                  marginTop: 6,
+                }}
+              >
+                过滤率较高，推荐流可能频繁加载
+              </Text>
+            )}
+          </RNView>
+        )}
+
+        {/* 启用总开关 */}
+        <Section title="内容过滤" colorScheme={colorScheme}>
+          <SettingItem
+            label="启用内容过滤"
+            icon="shield-checkmark-outline"
+            colorScheme={colorScheme}
+          >
+            <Switch
+              value={enableLocalFeedFilter}
+              onValueChange={(val) =>
+                updateSettings({ enableLocalFeedFilter: val })
+              }
+              {...switchProps}
+            />
+          </SettingItem>
+        </Section>
+
+        {enableLocalFeedFilter && (
+          <>
+            {/* 屏蔽推广与营销内容 */}
+            <Section title="屏蔽推广与营销内容" colorScheme={colorScheme}>
+              <Toggle
+                label="知乎盐选付费内容"
+                icon="diamond-outline"
+                colorScheme={colorScheme}
+                value={filterBlockPaid}
+                onValueChange={(v) => updateSettings({ filterBlockPaid: v })}
+                {...switchProps}
+              />
+              <Toggle
+                label="知乎广告平台推广"
+                icon="megaphone-outline"
+                colorScheme={colorScheme}
+                value={filterBlockAdPlatform}
+                onValueChange={(v) =>
+                  updateSettings({ filterBlockAdPlatform: v })
+                }
+                {...switchProps}
+              />
+              <Toggle
+                label="知乎学堂课程卡片"
+                icon="school-outline"
+                colorScheme={colorScheme}
+                value={filterBlockZhihuSchool}
+                onValueChange={(v) =>
+                  updateSettings({ filterBlockZhihuSchool: v })
+                }
+                {...switchProps}
+              />
+              <Toggle
+                label="微信公众号引流文章"
+                icon="logo-wechat"
+                colorScheme={colorScheme}
+                value={filterBlockWeChat}
+                onValueChange={(v) => updateSettings({ filterBlockWeChat: v })}
+                {...switchProps}
+              />
+              <Toggle
+                label="带推广标记的内容"
+                icon="pricetag-outline"
+                colorScheme={colorScheme}
+                value={filterBlockLabeled}
+                onValueChange={(v) => updateSettings({ filterBlockLabeled: v })}
+                {...switchProps}
+              />
+              <Toggle
+                label="机构号发布的内容"
+                icon="business-outline"
+                colorScheme={colorScheme}
+                value={filterBlockOrgAuthor}
+                onValueChange={(v) =>
+                  updateSettings({ filterBlockOrgAuthor: v })
+                }
+                {...switchProps}
+              />
+              <Toggle
+                label="广告主发布的内容"
+                icon="cash-outline"
+                colorScheme={colorScheme}
+                value={filterBlockAdvertiser}
+                onValueChange={(v) =>
+                  updateSettings({ filterBlockAdvertiser: v })
+                }
+                {...switchProps}
+              />
+            </Section>
+
+            {/* 过滤低质量内容 */}
+            <Section title="过滤低质量内容" colorScheme={colorScheme}>
+              <Toggle
+                label="启用质量过滤"
+                icon="bar-chart-outline"
+                colorScheme={colorScheme}
+                value={filterEnableQuality}
+                onValueChange={(v) =>
+                  updateSettings({ filterEnableQuality: v })
+                }
+                {...switchProps}
+              />
+              <SettingItem
+                label="过滤强度"
+                icon="speedometer-outline"
+                colorScheme={colorScheme}
+              >
+                <RNView style={s.row}>
+                  {QUALITY_LEVELS.map((lvl, i) => (
+                    <Pressable
+                      key={lvl.key}
+                      onPress={() =>
+                        updateSettings({ filterQualityLevel: lvl.key })
+                      }
+                      style={[
+                        s.tabChip,
+                        {
+                          backgroundColor:
+                            Colors[colorScheme].backgroundTertiary,
+                          marginLeft: i > 0 ? 8 : 0,
+                        },
+                        filterQualityLevel === lvl.key && {
+                          backgroundColor: tintColor,
+                        },
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          s.tabChipText,
+                          filterQualityLevel === lvl.key && {
+                            color: '#fff',
+                            fontWeight: 'bold',
+                          },
+                        ]}
+                      >
+                        {lvl.label}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </RNView>
+              </SettingItem>
+            </Section>
+
+            {/* 以下内容永不过滤 */}
+            <Section title="以下内容永不过滤" colorScheme={colorScheme}>
+              <Toggle
+                label="我关注的人发布的"
+                icon="heart-outline"
+                colorScheme={colorScheme}
+                value={filterKeepFollowing}
+                onValueChange={(v) =>
+                  updateSettings({ filterKeepFollowing: v })
+                }
+                {...switchProps}
+              />
+              <Toggle
+                label="我关注的人赞同过的"
+                icon="thumbs-up-outline"
+                colorScheme={colorScheme}
+                value={filterKeepUpvotedByFollowee}
+                onValueChange={(v) =>
+                  updateSettings({ filterKeepUpvotedByFollowee: v })
+                }
+                {...switchProps}
+              />
+            </Section>
+
+            {/* 被过滤内容的显示方式 */}
+            <Section title="被过滤内容的显示方式" colorScheme={colorScheme}>
+              <SettingItem
+                label="显示方式"
+                icon="eye-outline"
+                colorScheme={colorScheme}
+              >
+                <RNView style={s.row}>
+                  <Pressable
+                    onPress={() => updateSettings({ filterMode: 'collapse' })}
+                    style={[
+                      s.tabChip,
+                      {
+                        backgroundColor: Colors[colorScheme].backgroundTertiary,
+                        marginRight: 8,
+                      },
+                      filterMode === 'collapse' && {
+                        backgroundColor: tintColor,
+                      },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        s.tabChipText,
+                        filterMode === 'collapse' && {
+                          color: '#fff',
+                          fontWeight: 'bold',
+                        },
+                      ]}
+                    >
+                      折叠占位
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => updateSettings({ filterMode: 'hide' })}
+                    style={[
+                      s.tabChip,
+                      {
+                        backgroundColor: Colors[colorScheme].backgroundTertiary,
+                      },
+                      filterMode === 'hide' && { backgroundColor: tintColor },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        s.tabChipText,
+                        filterMode === 'hide' && {
+                          color: '#fff',
+                          fontWeight: 'bold',
+                        },
+                      ]}
+                    >
+                      直接隐藏
+                    </Text>
+                  </Pressable>
+                </RNView>
+              </SettingItem>
+              {filterMode === 'collapse' && (
+                <Toggle
+                  label="显示过滤原因"
+                  icon="information-circle-outline"
+                  colorScheme={colorScheme}
+                  value={filterShowReason}
+                  onValueChange={(v) => updateSettings({ filterShowReason: v })}
+                  {...switchProps}
+                />
+              )}
+            </Section>
+          </>
+        )}
+
+        {/* 推荐流（从「实验性功能」迁入） */}
+        <Section title="推荐流" colorScheme={colorScheme}>
+          <Toggle
+            label="本地 Feed 去重"
+            icon="layers-outline"
+            colorScheme={colorScheme}
+            value={enableLocalFeedDedup}
+            onValueChange={(v) => updateSettings({ enableLocalFeedDedup: v })}
+            {...switchProps}
+          />
+          <Toggle
+            label="启动时保留推荐流"
+            icon="bookmark-outline"
+            colorScheme={colorScheme}
+            value={enableFeedCacheOnLaunch}
+            onValueChange={(v) =>
+              updateSettings({ enableFeedCacheOnLaunch: v })
+            }
+            {...switchProps}
+          />
+          <SettingItem
+            label="清除本地去重记录"
+            icon="trash-bin-outline"
+            colorScheme={colorScheme}
+          >
+            <Pressable
+              onPress={() => {
+                Alert.alert(
+                  '清除本地去重记录',
+                  '清除后，近期看过的推荐内容可能再次出现。',
+                  [
+                    { text: '取消', style: 'cancel' },
+                    {
+                      text: '清除',
+                      style: 'destructive',
+                      onPress: async () => {
+                        try {
+                          await feedExposureRepository.clearAll();
+                          showToast('本地去重记录已清除');
+                        } catch (error) {
+                          console.error('清除本地去重记录失败', error);
+                          showToast('清除失败，请稍后重试');
+                        }
+                      },
+                    },
+                  ],
+                );
+              }}
+              className="px-3 py-1.5"
+            >
+              <Text style={{ color: Colors[colorScheme].danger }}>清除</Text>
+            </Pressable>
+          </SettingItem>
+        </Section>
+      </ScrollView>
+    </RNView>
+  );
+}
+
+// 内联 Toggle，避免每个开关都写一遍 SettingItem + Switch 模板
+function Toggle({
+  label,
+  icon,
+  colorScheme,
+  value,
+  onValueChange,
+  trackColor,
+}: {
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  colorScheme: 'light' | 'dark';
+  value: boolean;
+  onValueChange: (val: boolean) => void;
+  trackColor: { true: string; false?: string };
+}) {
+  return (
+    <SettingItem label={label} icon={icon} colorScheme={colorScheme}>
+      <Switch
+        value={value}
+        onValueChange={onValueChange}
+        trackColor={trackColor}
+      />
+    </SettingItem>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  statsCard: {
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 20,
+    borderWidth: 1,
+  },
+  statsTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 10,
+  },
+  statsBarTrack: {
+    height: 6,
+    borderRadius: 3,
+    overflow: 'hidden',
+  },
+});

--- a/app/settings/filter.tsx
+++ b/app/settings/filter.tsx
@@ -4,13 +4,11 @@ import { Stack } from 'expo-router';
 import { useMemo } from 'react';
 import {
   Alert,
-  Platform,
   Pressable,
   View as RNView,
   ScrollView,
   StyleSheet,
   Switch,
-  UIManager,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { FeedItem } from '@/api/zhihu';
@@ -26,14 +24,6 @@ import { feedExposureRepository } from '@/storage/feedExposureRepository';
 import { useSettingsStore } from '@/store/useSettingsStore';
 import { computeFilterStats } from '@/utils/feedFilter';
 import { showToast } from '@/utils/toast';
-
-// LayoutAnimation 在 Android 上需显式开启
-if (
-  Platform.OS === 'android' &&
-  UIManager.setLayoutAnimationEnabledExperimental
-) {
-  UIManager.setLayoutAnimationEnabledExperimental(true);
-}
 
 const QUALITY_LEVELS: {
   key: 'loose' | 'standard' | 'strict';

--- a/components/SettingItem.tsx
+++ b/components/SettingItem.tsx
@@ -1,0 +1,162 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import { View as RNView, StyleSheet } from 'react-native';
+import { Text } from '@/components/Themed';
+import Colors from '@/constants/Colors';
+
+/**
+ * 共享的设置页 UI 原语。两个设置页（外观与定制 / 过滤与推荐）共用，
+ * 避免各自的 Section/SettingItem 漂移。
+ */
+export function Section({
+  title,
+  children,
+  colorScheme,
+}: {
+  title: string;
+  children: React.ReactNode;
+  colorScheme: 'light' | 'dark';
+}) {
+  const isDark = colorScheme === 'dark';
+  const cardBg = isDark ? '#1C1C1E' : '#FFFFFF';
+  const dividerColor = isDark ? '#38383A' : '#E5E5EA';
+
+  // Section 内子元素由调用处逐个写死，数量与顺序在编译期就已固定。
+  const childArray = React.Children.toArray(children).filter(Boolean);
+
+  return (
+    <RNView style={styles.section}>
+      <Text style={styles.sectionTitle} type="secondary">
+        {title}
+      </Text>
+      <RNView style={[styles.sectionContent, { backgroundColor: cardBg }]}>
+        {childArray.map((child, index) => {
+          const isLast = index === childArray.length - 1;
+          return (
+            <RNView
+              // biome-ignore lint/suspicious/noArrayIndexKey: childArray 来自 React.Children,子元素在调用处的 JSX 里逐个写死,数量与顺序在编译期就固定了。
+              key={index}
+            >
+              {child}
+              {!isLast && (
+                <RNView
+                  style={[styles.divider, { backgroundColor: dividerColor }]}
+                />
+              )}
+            </RNView>
+          );
+        })}
+      </RNView>
+    </RNView>
+  );
+}
+
+export function SettingItem({
+  label,
+  icon,
+  children,
+  colorScheme,
+}: {
+  label: string;
+  icon?: keyof typeof Ionicons.glyphMap;
+  children: React.ReactNode;
+  colorScheme: 'light' | 'dark';
+}) {
+  return (
+    <RNView style={styles.settingItem}>
+      <RNView style={styles.settingLabelContainer}>
+        {icon && (
+          <RNView
+            style={[
+              styles.iconWrapper,
+              {
+                backgroundColor: colorScheme === 'dark' ? '#2C2C2E' : '#F2F2F7',
+              },
+            ]}
+          >
+            <Ionicons name={icon} size={16} color={Colors[colorScheme].text} />
+          </RNView>
+        )}
+        <Text style={styles.settingLabel}>{label}</Text>
+      </RNView>
+      {children}
+    </RNView>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: { marginBottom: 28 },
+  sectionTitle: {
+    fontSize: 13,
+    marginBottom: 8,
+    marginLeft: 16,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  sectionContent: {
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: 48, // 避开 Icon 区域的分割线
+  },
+  settingItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    minHeight: 52,
+  },
+  settingLabelContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  iconWrapper: {
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  settingLabel: { fontSize: 16 },
+});
+
+/**
+ * 多个设置页共用的 chip / 步进器布局原语（外观页已有等价的本地 styles，
+ * 这里抽出来是为了让「过滤与推荐」页不必再复制一份）。
+ */
+export const settingsChipStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'transparent',
+  },
+  smallBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  valueText: {
+    width: 48,
+    textAlign: 'center',
+    fontSize: 15,
+    fontWeight: 'bold',
+  },
+  tabGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    padding: 16,
+  },
+  tabChip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+  },
+  tabChipText: { fontSize: 14 },
+});

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -74,7 +74,7 @@ export interface AppSettings {
   /** 过滤总开关。默认关：行为改变型功能不在升级后静默生效。 */
   enableLocalFeedFilter: boolean;
   /** 被过滤内容的展示方式：折叠占位（默认）或直接隐藏。 */
-  filterMode: 'collapse' | 'hide';
+  filterMode: FilterMode;
   /** 折叠模式下是否在占位行上显示原因文案（仅折叠模式有载体）。 */
   filterShowReason: boolean;
   // 推广 / 营销类开关型规则
@@ -96,7 +96,7 @@ export interface AppSettings {
   /** 质量过滤开关，与上面推广开关独立。 */
   filterEnableQuality: boolean;
   /** 三档强度阈值，驱动四类内容的组合条件（详见 utils/feedFilter.ts）。 */
-  filterQualityLevel: 'loose' | 'standard' | 'strict';
+  filterQualityLevel: FilterQualityLevel;
   // 豁免
   /** 关注作者的内容永不过滤（质量规则的内建豁免依据） */
   filterKeepFollowing: boolean;

--- a/store/useSettingsStore.ts
+++ b/store/useSettingsStore.ts
@@ -1,6 +1,7 @@
 import * as SecureStore from 'expo-secure-store';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
+import type { FilterMode, FilterQualityLevel } from '@/utils/feedFilter';
 
 const settingsStorage = {
   getItem: (name: string) => SecureStore.getItemAsync(name),
@@ -18,6 +19,23 @@ function isValidHex(color: string | null | undefined): boolean {
 /** Sanitize a color value: returns the color if valid, null otherwise */
 function sanitizeColor(color: string | null | undefined): string | null {
   return isValidHex(color) ? (color as string) : null;
+}
+
+const VALID_FILTER_MODES: ReadonlyArray<FilterMode> = ['collapse', 'hide'];
+const VALID_QUALITY_LEVELS: ReadonlyArray<FilterQualityLevel> = [
+  'loose',
+  'standard',
+  'strict',
+];
+
+function isValidFilterMode(v: unknown): v is FilterMode {
+  return typeof v === 'string' && (VALID_FILTER_MODES as string[]).includes(v);
+}
+
+function isValidQualityLevel(v: unknown): v is FilterQualityLevel {
+  return (
+    typeof v === 'string' && (VALID_QUALITY_LEVELS as string[]).includes(v)
+  );
 }
 
 export type TabKey =
@@ -51,6 +69,39 @@ export interface AppSettings {
   enableLocalFeedDedup: boolean;
   /** 是否在冷启动时保留上次的推荐流内容 */
   enableFeedCacheOnLaunch: boolean;
+
+  // —— 本地内容过滤（见 utils/feedFilter.ts）——
+  /** 过滤总开关。默认关：行为改变型功能不在升级后静默生效。 */
+  enableLocalFeedFilter: boolean;
+  /** 被过滤内容的展示方式：折叠占位（默认）或直接隐藏。 */
+  filterMode: 'collapse' | 'hide';
+  /** 折叠模式下是否在占位行上显示原因文案（仅折叠模式有载体）。 */
+  filterShowReason: boolean;
+  // 推广 / 营销类开关型规则
+  /** answer_type === 'PAID' 或 paid_info != null（知乎盐选付费内容） */
+  filterBlockPaid: boolean;
+  /** 正文含 xg.zhihu.com（知乎广告平台推流） */
+  filterBlockAdPlatform: boolean;
+  /** 正文含 d.zhihu.com / data-edu-card-id（知乎学堂课程卡片） */
+  filterBlockZhihuSchool: boolean;
+  /** 正文含 mp.weixin.qq.com（微信公众号引流文章） */
+  filterBlockWeChat: boolean;
+  /** is_labeled（带推广标记的内容） */
+  filterBlockLabeled: boolean;
+  /** author.is_org（机构号发布的内容；默认放行，机构号也有正经内容） */
+  filterBlockOrgAuthor: boolean;
+  /** author.is_advertiser（广告主发布的内容） */
+  filterBlockAdvertiser: boolean;
+  // 内容质量过滤
+  /** 质量过滤开关，与上面推广开关独立。 */
+  filterEnableQuality: boolean;
+  /** 三档强度阈值，驱动四类内容的组合条件（详见 utils/feedFilter.ts）。 */
+  filterQualityLevel: 'loose' | 'standard' | 'strict';
+  // 豁免
+  /** 关注作者的内容永不过滤（质量规则的内建豁免依据） */
+  filterKeepFollowing: boolean;
+  /** 我关注的人赞过的内容永不过滤 */
+  filterKeepUpvotedByFollowee: boolean;
 }
 
 interface SettingsState extends AppSettings {
@@ -74,6 +125,20 @@ const DEFAULT_SETTINGS: AppSettings = {
   enableBrowseHistory: true,
   enableLocalFeedDedup: false,
   enableFeedCacheOnLaunch: false,
+  enableLocalFeedFilter: false,
+  filterMode: 'collapse',
+  filterShowReason: true,
+  filterBlockPaid: true,
+  filterBlockAdPlatform: true,
+  filterBlockZhihuSchool: true,
+  filterBlockWeChat: true,
+  filterBlockLabeled: true,
+  filterBlockOrgAuthor: false,
+  filterBlockAdvertiser: true,
+  filterEnableQuality: true,
+  filterQualityLevel: 'standard',
+  filterKeepFollowing: true,
+  filterKeepUpvotedByFollowee: true,
 };
 
 export const useSettingsStore = create<SettingsState>()(
@@ -100,6 +165,13 @@ export const useSettingsStore = create<SettingsState>()(
           }
           // 兜底：非法 hex 颜色退回默认（null）
           nextSettings.primaryColor = sanitizeColor(nextSettings.primaryColor);
+          // 兜底：过滤 union 字段写入非枚举值时退回默认
+          if (!isValidFilterMode(nextSettings.filterMode)) {
+            nextSettings.filterMode = 'collapse';
+          }
+          if (!isValidQualityLevel(nextSettings.filterQualityLevel)) {
+            nextSettings.filterQualityLevel = 'standard';
+          }
           return nextSettings;
         }),
       resetSettings: () => set(DEFAULT_SETTINGS),
@@ -107,7 +179,7 @@ export const useSettingsStore = create<SettingsState>()(
     {
       name: 'zhihu-settings-storage',
       storage: createJSONStorage(() => settingsStorage),
-      version: 7,
+      version: 8,
       migrate: (persistedState: any, version: number) => {
         // 清理历史脏数据：null 或非法 hex 都退回默认蓝
         const sanitized = sanitizeColor(persistedState?.primaryColor);
@@ -138,6 +210,43 @@ export const useSettingsStore = create<SettingsState>()(
         if (version < 7) {
           persistedState.enableFeedCacheOnLaunch =
             persistedState.enableFeedCacheOnLaunch ?? false;
+        }
+
+        // 升级到 v8 时兜底本地内容过滤字段
+        if (version < 8) {
+          persistedState.enableLocalFeedFilter = false;
+          persistedState.filterMode = isValidFilterMode(
+            persistedState.filterMode,
+          )
+            ? persistedState.filterMode
+            : 'collapse';
+          persistedState.filterShowReason =
+            persistedState.filterShowReason ?? true;
+          persistedState.filterBlockPaid =
+            persistedState.filterBlockPaid ?? true;
+          persistedState.filterBlockAdPlatform =
+            persistedState.filterBlockAdPlatform ?? true;
+          persistedState.filterBlockZhihuSchool =
+            persistedState.filterBlockZhihuSchool ?? true;
+          persistedState.filterBlockWeChat =
+            persistedState.filterBlockWeChat ?? true;
+          persistedState.filterBlockLabeled =
+            persistedState.filterBlockLabeled ?? true;
+          persistedState.filterBlockOrgAuthor =
+            persistedState.filterBlockOrgAuthor ?? false;
+          persistedState.filterBlockAdvertiser =
+            persistedState.filterBlockAdvertiser ?? true;
+          persistedState.filterEnableQuality =
+            persistedState.filterEnableQuality ?? true;
+          persistedState.filterQualityLevel = isValidQualityLevel(
+            persistedState.filterQualityLevel,
+          )
+            ? persistedState.filterQualityLevel
+            : 'standard';
+          persistedState.filterKeepFollowing =
+            persistedState.filterKeepFollowing ?? true;
+          persistedState.filterKeepUpvotedByFollowee =
+            persistedState.filterKeepUpvotedByFollowee ?? true;
         }
 
         return persistedState as SettingsState;

--- a/utils/feedFilter.ts
+++ b/utils/feedFilter.ts
@@ -1,0 +1,261 @@
+/**
+ * 本地推荐流过滤管线。
+ *
+ * 字段依据见 api/zhihu/feed.ts 的 FeedItem 注释——所有信号都来自实测推荐流可用字段，
+ * 不依赖项目过往读取过但接口实际不返回的字段（favlists_count / author.followers_count）。
+ *
+ * 过滤分两条独立的可调开关族：
+ *   - 推广/营销：盐选、广告平台、知乎学堂、微信引流、推广标注、机构号、广告主
+ *   - 内容质量：三档强度阈值，按内容类型走组合条件
+ *
+ * 豁免（关注作者 / 关注者赞过）作为独立开关，且默认开启，判在广告与质量之前。
+ */
+
+import type { FeedItem } from '@/api/zhihu';
+import { getInMemoryFeedKey } from '@/utils/feedIdentity';
+
+const LOCAL_FEED_FILTER_TABS = new Set(['recommend']);
+
+/** 仅推荐流参与本地过滤。 */
+export function supportsLocalFeedFilter(tab: string): boolean {
+  return LOCAL_FEED_FILTER_TABS.has(tab);
+}
+
+export type FilterMode = 'collapse' | 'hide';
+export type FilterQualityLevel = 'loose' | 'standard' | 'strict';
+
+/** 由 useSettingsStore 的扁平字段派生出的过滤规则集。 */
+export interface FeedFilterRules {
+  /** 推广 / 营销类开关 */
+  blockPaid: boolean;
+  blockAdPlatform: boolean;
+  blockZhihuSchool: boolean;
+  blockWeChat: boolean;
+  blockLabeled: boolean;
+  blockOrgAuthor: boolean;
+  blockAdvertiser: boolean;
+  /** 内容质量过滤总开关 */
+  enableQuality: boolean;
+  qualityLevel: FilterQualityLevel;
+  /** 永不过滤（豁免） */
+  keepFollowing: boolean;
+  keepUpvotedByFollowee: boolean;
+}
+
+export type FilterCategory = 'ad' | 'quality';
+
+export interface FilterVerdict {
+  /** null = 保留；非空字符串为人类可读过滤原因。 */
+  reason: string | null;
+  category: FilterCategory;
+}
+
+const KEEP: FilterVerdict = { reason: null, category: 'ad' };
+
+/** 折叠模式下合并连续命中项形成的占位行。 */
+export interface CollapsedGroup {
+  kind: 'collapsed';
+  /** 组内首条的内存 key，保证 FlashList key 在折叠 / 展开切换间稳定。 */
+  groupKey: string;
+  items: FeedItem[];
+  /** 去重后的原因文案列表。 */
+  reasons: string[];
+}
+
+export type FilteredFeedItem = FeedItem | CollapsedGroup;
+
+/**
+ * 三档强度阈值。「标准」采用 Zhihu++ 实测值。
+ * 问题类型当且仅当 answerCount / followerCount 缺失时跳过判定——
+ * 推荐流几乎不返回 question 类型的 feed 项，缺失即保留，避免误杀。
+ */
+const QUALITY_THRESHOLDS: Record<
+  FilterQualityLevel,
+  {
+    answerVote: number;
+    articleVote: number;
+    pinVote: number;
+    questionAnswer: number;
+    questionFollower: number;
+  }
+> = {
+  loose: {
+    answerVote: 5,
+    articleVote: 10,
+    pinVote: 10,
+    questionAnswer: 3,
+    questionFollower: 20,
+  },
+  standard: {
+    answerVote: 10,
+    articleVote: 20,
+    pinVote: 20,
+    questionAnswer: 5,
+    questionFollower: 50,
+  },
+  strict: {
+    answerVote: 50,
+    articleVote: 50,
+    pinVote: 50,
+    questionAnswer: 10,
+    questionFollower: 100,
+  },
+};
+
+/** 在折叠 / 隐藏模式都需要对单项的判定。 */
+export function evaluateFeedItem(
+  item: FeedItem,
+  rules: FeedFilterRules,
+): FilterVerdict {
+  // 1. 豁免最先：放在后面会导致关注作者的低赞内容先命中质量规则。
+  if (rules.keepFollowing && item.isFollowingAuthor) return KEEP;
+  if (rules.keepUpvotedByFollowee && item.upvotedByFollowee) return KEEP;
+
+  // 2. 推广 / 营销
+  if (rules.blockPaid && isPaidAnswer(item)) {
+    return { reason: '知乎盐选付费内容', category: 'ad' };
+  }
+  const content = typeof item.content === 'string' ? item.content : '';
+  if (rules.blockAdPlatform && content.includes('xg.zhihu.com')) {
+    return { reason: '知乎广告平台推广', category: 'ad' };
+  }
+  if (
+    rules.blockZhihuSchool &&
+    (content.includes('d.zhihu.com') || content.includes('data-edu-card-id'))
+  ) {
+    return { reason: '知乎学堂课程卡片', category: 'ad' };
+  }
+  if (rules.blockWeChat && content.includes('mp.weixin.qq.com')) {
+    return { reason: '微信公众号引流文章', category: 'ad' };
+  }
+  if (rules.blockLabeled && item.isLabeled) {
+    return { reason: '带推广标记的内容', category: 'ad' };
+  }
+  if (rules.blockOrgAuthor && item.isOrgAuthor) {
+    return { reason: '机构号发布的内容', category: 'ad' };
+  }
+  if (rules.blockAdvertiser && item.isAdvertiser) {
+    return { reason: '广告主发布的内容', category: 'ad' };
+  }
+
+  // 3. 内容质量：按类型的组合条件
+  if (rules.enableQuality) {
+    const t = QUALITY_THRESHOLDS[rules.qualityLevel];
+    const reason = qualityReason(item, t);
+    if (reason) return { reason, category: 'quality' };
+  }
+
+  return KEEP;
+}
+
+/** `answer_type === 'PAID'` 或 `paid_info != null`，两个版本接口的信号取或。 */
+function isPaidAnswer(item: FeedItem): boolean {
+  return item.answerType === 'PAID';
+}
+
+function qualityReason(
+  item: FeedItem,
+  t: (typeof QUALITY_THRESHOLDS)[FilterQualityLevel],
+): string | null {
+  switch (item.type) {
+    case 'answers':
+      if (item.voteCount < t.answerVote) return `赞同数 < ${t.answerVote}`;
+      return null;
+    case 'articles':
+      if (item.voteCount < t.articleVote) return `赞同数 < ${t.articleVote}`;
+      return null;
+    case 'pins':
+      if (item.voteCount < t.pinVote) return `赞同数 < ${t.pinVote}`;
+      return null;
+    case 'questions':
+      if (item.answerCount == null || item.followerCount == null) return null;
+      if (
+        item.answerCount < t.questionAnswer &&
+        item.followerCount < t.questionFollower
+      ) {
+        return `回答数 < ${t.questionAnswer} / 关注数 < ${t.questionFollower}`;
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+/** 把过滤后展平的列表转成可包含折叠占位的数组。 */
+export function applyFeedFilter(
+  items: FeedItem[],
+  rules: FeedFilterRules,
+  mode: FilterMode,
+): FilteredFeedItem[] {
+  if (mode === 'hide') {
+    return items.filter(
+      (item) => evaluateFeedItem(item, rules).reason === null,
+    );
+  }
+
+  const out: FilteredFeedItem[] = [];
+  let pending: { items: FeedItem[]; reasons: Set<string> } | null = null;
+
+  const flush = () => {
+    if (!pending || pending.items.length === 0) {
+      pending = null;
+      return;
+    }
+    const firstKey = getInMemoryFeedKey(pending.items[0]);
+    out.push({
+      kind: 'collapsed',
+      groupKey: firstKey || `collapsible-${out.length}`,
+      items: pending.items,
+      reasons: Array.from(pending.reasons),
+    });
+    pending = null;
+  };
+
+  for (const item of items) {
+    const verdict = evaluateFeedItem(item, rules);
+    if (verdict.reason === null) {
+      flush();
+      out.push(item);
+    } else {
+      if (!pending) pending = { items: [], reasons: new Set() };
+      pending.items.push(item);
+      pending.reasons.add(verdict.reason);
+    }
+  }
+  flush();
+  return out;
+}
+
+/** 判断列表项是否为折叠占位行（keyExtractor / renderItem 前置判断用）。 */
+export function isCollapsedGroup(item: unknown): item is CollapsedGroup {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    (item as CollapsedGroup).kind === 'collapsed'
+  );
+}
+
+/** 供设置页「实时效果条」估算过滤率与原因分布，不发请求。 */
+export interface FilterStats {
+  total: number;
+  filtered: number;
+  rate: number; // 0 ~ 1
+  reasons: Record<string, number>;
+}
+
+export function computeFilterStats(
+  items: FeedItem[],
+  rules: FeedFilterRules,
+): FilterStats {
+  let filtered = 0;
+  const reasons: Record<string, number> = {};
+  for (const item of items) {
+    const v = evaluateFeedItem(item, rules);
+    if (v.reason !== null) {
+      filtered += 1;
+      reasons[v.reason] = (reasons[v.reason] ?? 0) + 1;
+    }
+  }
+  const total = items.length;
+  return { total, filtered, rate: total === 0 ? 0 : filtered / total, reasons };
+}

--- a/utils/feedFilter.ts
+++ b/utils/feedFilter.ts
@@ -148,14 +148,17 @@ export function evaluateFeedItem(
   return KEEP;
 }
 
-/** `answer_type === 'PAID'` 或 `paid_info != null`，两个版本接口的信号取或。 */
+/** 盐选判定。双信号（answer_type === 'PAID' 或 paid_info != null）已在
+ * parseRecommendData 解析阶段归一成 answerType === 'PAID'，这里只读结果。 */
 function isPaidAnswer(item: FeedItem): boolean {
   return item.answerType === 'PAID';
 }
 
+type QualityThreshold = (typeof QUALITY_THRESHOLDS)[FilterQualityLevel];
+
 function qualityReason(
   item: FeedItem,
-  t: (typeof QUALITY_THRESHOLDS)[FilterQualityLevel],
+  t: QualityThreshold,
 ): string | null {
   switch (item.type) {
     case 'answers':


### PR DESCRIPTION
### 📝 功能描述

本 PR 引入了**本地推荐流内容过滤与防打扰设置**功能。支持根据推广营销特征（盐选付费、广告平台、微信引流、机构号/广告主等）及内容质量阈值（三档强度）在本地筛选推荐流，并提供折叠占位或直接隐藏两种模式。

感谢 @Xeonzilla 的优质贡献！🎉

---

### ✨ 主要变动

#### 1. 过滤规则引擎 (`utils/feedFilter.ts`)
- **展示模式**：支持 `折叠占位`（默认，展示折叠数量与原因，支持点击展开/收起）与 `直接隐藏` 两种模式。
- **规则分类**：
  - **推广与营销**：知乎盐选付费（`PAID`）、知乎广告平台（`xg.zhihu.com`）、知乎学堂卡片、微信公众号引流（`mp.weixin.qq.com`）、带推广标记、机构号、广告主。
  - **内容质量**：提供宽松 / 标准 / 严格三档强度阈值，按内容类型（回答、文章、想法、问题）筛选低赞同数或低互动量内容。
  - **豁免机制**：关注作者的内容及关注者赞过的作者永不过滤，优先级高于质量规则。

#### 2. 设置页与 UI 原语 (`app/settings/filter.tsx` & `components/SettingItem.tsx`)
- 新增 **「过滤与推荐」** 设置页：
  - **实时效果预览卡片**：基于当前本地推荐流缓存计算预估过滤率及原因分布。
  - 过滤总开关、展示模式、营销分类开关、质量筛选强度及豁免选项。
  - 整合并迁移原“外观与定制”中的推荐流去重与冷启动缓存设置。
- 抽取 `Section` 与 `SettingItem` 共享设置项原语，统一设置页外观规范。

#### 3. 数据解析与列表对接 (`api/zhihu/feed.ts` & `app/(tabs)/index.tsx`)
- 扩展 `FeedItem` 信号字段解析（盐选状态、机构号标记、关注作者判定、赞同数/关注数等）。
- `FlashList` 集成折叠占位卡片渲染与展开/收起交互，刷新时自动重置展开状态；忽略占位卡片的曝光记录。

---

### 🧪 校验情况

- [x] TypeScript 类型检查通过 (`npx tsc --noEmit`)
- [x] 兼容已有的设置存储升级迁移 (Store version 8)
