### PR TITLE
fix: 同步作者关注状态与提示

### DIFF
--- a/api/zhihu/answer.ts
+++ b/api/zhihu/answer.ts
@@ -62,7 +62,7 @@ export const getAnswer = async (
   include?: string,
 ): Promise<AnswerDetail> => {
   const defaultInclude =
-    'content,paid_info,can_comment,excerpt,thanks_count,voteup_count,comment_count,visited_count,reaction,ip_info,question.topics,reaction.relation.voting,segment_infos,favlists_count';
+    'content,paid_info,can_comment,excerpt,thanks_count,voteup_count,comment_count,visited_count,reaction,ip_info,question.topics,author.is_following,reaction.relation.voting,segment_infos,favlists_count';
   const res = await apiClient.get(
     `/answers/${id}?include=${include || defaultInclude}`,
   );

--- a/api/zhihu/article.ts
+++ b/api/zhihu/article.ts
@@ -1,7 +1,12 @@
+import type { ZhihuArticle } from '@/types/zhihu';
 import apiClient from '../client';
 
-export const getArticle = async (id: string | number) => {
-  const res = await apiClient.get(`/articles/${id}`);
+export const getArticle = async (
+  id: string | number,
+): Promise<ZhihuArticle> => {
+  const res = await apiClient.get(`/articles/${id}`, {
+    params: { include: 'author.is_following' },
+  });
   return res.data;
 };
 

--- a/api/zhihu/pin.ts
+++ b/api/zhihu/pin.ts
@@ -2,7 +2,7 @@ import client from '../client';
 
 export const getPin = async (id: string | number) => {
   const include =
-    'author,content,content_html,created,like_count,comment_count,relationship.voting';
+    'author,author.is_following,content,content_html,created,like_count,comment_count,relationship.voting';
   const res = await client.get(`/pins/${id}?include=${include}`);
   return res.data;
 };

--- a/app/article/[id].tsx
+++ b/app/article/[id].tsx
@@ -36,6 +36,7 @@ import { ZhihuContent } from '@/features/rich-content';
 import { useOptimisticToggle } from '@/hooks/useOptimisticToggle';
 import { useCollectionStore } from '@/store/useCollectionStore';
 import { useSettingsStore } from '@/store/useSettingsStore';
+import type { ZhihuArticle } from '@/types/zhihu';
 import { formatDate } from '@/utils/date';
 import { showToast } from '@/utils/toast';
 
@@ -142,7 +143,8 @@ export default function ArticleDetail() {
   });
 
   // 4. 关注作者逻辑
-  const followMutation = useOptimisticToggle({
+  const followMutation = useOptimisticToggle<ZhihuArticle>({
+    queryKey: ['zhihu-article', id],
     mutationFn: async () => {
       if (data?.author?.is_following) {
         return unfollowMember(data.author.url_token || data.author.id);
@@ -150,8 +152,16 @@ export default function ArticleDetail() {
       return followMember(data.author.url_token || data.author.id);
     },
     isActive: data?.author?.is_following,
+    onUpdateCache: (old) => ({
+      ...old,
+      author: old.author
+        ? {
+            ...old.author,
+            is_following: !old.author.is_following,
+          }
+        : old.author,
+    }),
     successMessage: (isActive) => (isActive ? '已取消关注' : '已关注'),
-    invalidateQueries: [['zhihu-article', id]],
   });
 
   // 5. 获取专栏卡片信息

--- a/app/pin/[id].tsx
+++ b/app/pin/[id].tsx
@@ -23,6 +23,7 @@ import Colors from '@/constants/Colors';
 import { ZhihuContent } from '@/features/rich-content';
 import { useOptimisticToggle } from '@/hooks/useOptimisticToggle';
 import { useSettingsStore } from '@/store/useSettingsStore';
+import type { ZhihuPin } from '@/types/zhihu';
 import { formatDateTime } from '@/utils/date';
 
 export default function PinDetailScreen() {
@@ -59,15 +60,24 @@ export default function PinDetailScreen() {
     }
   }, [enableBrowseHistory, pin?.id]);
 
-  const followMutation = useOptimisticToggle({
+  const followMutation = useOptimisticToggle<Pick<ZhihuPin, 'author'>>({
+    queryKey: ['pin-detail', id],
     mutationFn: async () => {
-      if (pin?.author?.is_following)
-        return unfollowMember(pin.author.url_token || pin.author.id);
-      return followMember(pin.author.url_token || pin.author.id);
+      const author = pin?.author;
+      if (!author) throw new Error('想法尚未加载');
+      if (author.is_following)
+        return unfollowMember(author.url_token || author.id);
+      return followMember(author.url_token || author.id);
     },
     isActive: pin?.author?.is_following,
+    onUpdateCache: (old) => ({
+      ...old,
+      author: {
+        ...old.author,
+        is_following: !old.author.is_following,
+      },
+    }),
     successMessage: (isActive) => (isActive ? '已取消关注' : '已关注'),
-    invalidateQueries: [['pin-detail', id]],
   });
 
   const goToProfile = useCallback(() => {

--- a/app/question/[id]/index.tsx
+++ b/app/question/[id]/index.tsx
@@ -1,6 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
 import { FlashList } from '@shopify/flash-list';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  type InfiniteData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { BlurView } from 'expo-blur';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
@@ -38,7 +43,7 @@ import Reanimated, {
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import client from '@/api/client';
-import { deleteAnswer } from '@/api/zhihu/answer';
+import { type AnswerDetail, deleteAnswer } from '@/api/zhihu/answer';
 import { addReadHistory } from '@/api/zhihu/history';
 import { followMember, unfollowMember } from '@/api/zhihu/member';
 import {
@@ -63,6 +68,14 @@ import { useSettingsStore } from '@/store/useSettingsStore';
 import { formatDate } from '@/utils/date';
 import { refreshInfiniteQuery } from '@/utils/query';
 
+interface QuestionAnswersPage {
+  data?: AnswerDetail[];
+  paging?: {
+    is_end?: boolean;
+    next?: string;
+  };
+}
+
 const AnswerItem = forwardRef(
   (
     {
@@ -70,6 +83,8 @@ const AnswerItem = forwardRef(
       isExpanded,
       onToggle,
       onShare,
+      questionId,
+      sortBy,
       screenTranslateX,
       onSwipeStart,
       onSwipeComplete,
@@ -256,7 +271,10 @@ const AnswerItem = forwardRef(
       </View>
     ) : null;
 
-    const followMutation = useOptimisticToggle({
+    const followMutation = useOptimisticToggle<
+      InfiniteData<QuestionAnswersPage, number>
+    >({
+      queryKey: ['question-answers', questionId, sortBy],
       mutationFn: async () => {
         const pid = item.author?.url_token || item.author?.id;
         if (!pid) return;
@@ -264,8 +282,24 @@ const AnswerItem = forwardRef(
         return followMember(pid);
       },
       isActive: item.author?.is_following,
+      onUpdateCache: (old) => ({
+        ...old,
+        pages: old.pages.map((page) => ({
+          ...page,
+          data: page.data?.map((answer) =>
+            answer.id.toString() === item.id?.toString()
+              ? {
+                  ...answer,
+                  author: {
+                    ...answer.author,
+                    is_following: !answer.author.is_following,
+                  },
+                }
+              : answer,
+          ),
+        })),
+      }),
       successMessage: (isActive) => (isActive ? '已取消关注' : '已关注'),
-      invalidateQueries: [['question-answers']],
     });
 
     const deleteMutation = useMutation({

--- a/components/AnswerDetailView.tsx
+++ b/components/AnswerDetailView.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react-native';
 import { SharedTransition } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { deleteAnswer, getAnswer } from '@/api/zhihu';
+import { type AnswerDetail, deleteAnswer, getAnswer } from '@/api/zhihu';
 import {
   fastCollectAnswer,
   getAnswerCollectionStatus,
@@ -99,7 +99,8 @@ export const AnswerDetailView = ({
       err?.response?.status === 404 ? false : failureCount < 2,
   });
 
-  const followMutation = useOptimisticToggle({
+  const followMutation = useOptimisticToggle<AnswerDetail>({
+    queryKey: ['answer-detail', id],
     mutationFn: async () => {
       const author = answer?.author;
       if (!author) throw new Error('回答尚未加载');
@@ -108,8 +109,14 @@ export const AnswerDetailView = ({
       return followMember(author.url_token || author.id);
     },
     isActive: answer?.author?.is_following,
+    onUpdateCache: (old) => ({
+      ...old,
+      author: {
+        ...old.author,
+        is_following: !old.author.is_following,
+      },
+    }),
     successMessage: (isActive) => (isActive ? '已取消关注' : '已关注'),
-    invalidateQueries: [['answer-detail', id]],
   });
 
   const deleteMutation = useMutation({

--- a/hooks/useOptimisticToggle.ts
+++ b/hooks/useOptimisticToggle.ts
@@ -5,9 +5,9 @@ import {
 } from '@tanstack/react-query';
 import { showToast } from '@/utils/toast';
 
-export interface UseOptimisticToggleOptions<TData = any> {
+export interface UseOptimisticToggleOptions<TData = unknown> {
   queryKey?: QueryKey;
-  mutationFn: () => Promise<any>;
+  mutationFn: () => Promise<unknown>;
   onUpdateCache?: (oldData: TData) => TData;
   successMessage?: ((isActive: boolean) => string) | string;
   errorMessage?: string;
@@ -16,7 +16,7 @@ export interface UseOptimisticToggleOptions<TData = any> {
   invalidateQueries?: QueryKey[];
 }
 
-export function useOptimisticToggle<TData = any>({
+export function useOptimisticToggle<TData = unknown>({
   queryKey,
   mutationFn,
   onUpdateCache,
@@ -31,28 +31,31 @@ export function useOptimisticToggle<TData = any>({
   return useMutation({
     mutationFn,
     onMutate: async () => {
-      if (!queryKey || !onUpdateCache) return { previous: undefined };
+      const wasActive = isActive;
+      if (!queryKey || !onUpdateCache) {
+        return { previous: undefined, wasActive };
+      }
 
       await queryClient.cancelQueries({ queryKey });
       const previous = queryClient.getQueryData<TData>(queryKey);
 
-      if (previous) {
+      if (previous !== undefined) {
         queryClient.setQueryData<TData>(queryKey, onUpdateCache(previous));
       }
 
-      return { previous };
+      return { previous, wasActive };
     },
     onError: (_err, _variables, context) => {
-      if (context?.previous && queryKey) {
+      if (context?.previous !== undefined && queryKey) {
         queryClient.setQueryData(queryKey, context.previous);
       }
       showToast(errorMessage);
     },
-    onSuccess: () => {
+    onSuccess: (_data, _variables, context) => {
       if (successMessage) {
         const msg =
           typeof successMessage === 'function'
-            ? successMessage(isActive)
+            ? successMessage(context.wasActive)
             : successMessage;
         showToast(msg);
       }


### PR DESCRIPTION
## 概要

- 文章详情显式获取作者关注状态，并乐观更新“关注/已关注”按钮
- 修复关注成功 toast 使用切换后状态、导致提示文字反向的问题
- 审计并修复回答详情、想法详情和问题页回答作者的同类关注状态问题
- 请求失败时回滚本地缓存，完成后重新与服务端状态同步

## 验证

- `./node_modules/.bin/tsc --noEmit`
- `npm run test:rich-content`（15 tests passed）
- `git diff --check`
- Biome 检查通过（保留仓库既有的 `any` 警告；问题页既有 exhaustive-deps 报告未纳入本次修复）

Closes #44