### PR TITLE
fix(ios): avoid duplicate cookies in signed API requests

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -8,7 +8,33 @@ import { signRequest96, ZSE_VERSION } from './zse96/index';
 const apiClient = axios.create({
   baseURL: 'https://www.zhihu.com/api/v4',
   timeout: 10000,
+  // React Native XHR defaults to withCredentials=true. On iOS that makes
+  // RCTNetworking load NSHTTPCookieStorage first, then append our signed
+  // request's explicit Cookie header, which can send duplicate/stale cookies.
+  withCredentials: false,
 });
+
+const requestIds = new WeakMap<object, string>();
+let requestSequence = 0;
+
+function getSafePath(url?: string) {
+  if (!url) return '<unknown>';
+  try {
+    return new URL(url, 'https://www.zhihu.com').pathname;
+  } catch {
+    return url.split('?')[0];
+  }
+}
+
+function getRequestId(config?: object) {
+  if (!config) return 'unknown';
+  const existing = requestIds.get(config);
+  if (existing) return existing;
+  requestSequence += 1;
+  const requestId = `local-${requestSequence}`;
+  requestIds.set(config, requestId);
+  return requestId;
+}
 
 function getDc0(cookie: string) {
   const match = cookie.match(/d_c0=([^;]+)/);
@@ -21,9 +47,9 @@ function getXsrf(cookie: string) {
 }
 
 apiClient.interceptors.request.use(async (config) => {
+  const requestId = getRequestId(config);
   console.log(
-    `🌐 [API Request] ${config.method?.toUpperCase()} ${config.url}`,
-    config.params ? JSON.stringify(config.params) : '',
+    `🌐 [API ${requestId}] ${config.method?.toUpperCase()} ${getSafePath(config.url)}`,
   );
   // 优先从 AuthStore 获取，如果没有再尝试从 SecureStore (向下兼容)
   let cookie =
@@ -41,7 +67,6 @@ apiClient.interceptors.request.use(async (config) => {
         cookie = Object.entries(nativeCookies)
           .map(([name, c]) => `${name}=${c.value}`)
           .join('; ');
-        console.log('🍪 提取到的原生访客 Cookie:', cookie);
       }
     } catch (e) {
       console.warn('获取原生 cookie 失败', e);
@@ -78,14 +103,18 @@ apiClient.interceptors.request.use(async (config) => {
 
 apiClient.interceptors.response.use(
   (response) => {
+    const requestId = getRequestId(response.config);
     console.log(
-      `✅ [API Response] ${response.config.method?.toUpperCase()} ${response.config.url} Status: ${response.status}`,
+      `✅ [API ${requestId}] ${response.config.method?.toUpperCase()} ${getSafePath(response.config.url)} Status: ${response.status}`,
     );
     return response;
   },
   (error) => {
+    const requestId = getRequestId(error.config);
+    const method = error.config?.method?.toUpperCase() || '<unknown>';
+    const path = getSafePath(error.config?.url);
     if (error.response?.status === 401) {
-      console.warn('请登陆后再尝试');
+      console.warn(`⚠️ [API ${requestId}] ${method} ${path} Status: 401`);
     }
     // 处理人机验证 40352
     if (error.response?.data?.error?.code === 40352) {
@@ -97,17 +126,10 @@ apiClient.interceptors.response.use(
     }
 
     if (error.response?.status === 404) {
-      console.warn(
-        `⚠️ [API 404] 资源不存在: ${error.config?.url}`,
-        error.response?.data?.error?.message || '',
-      );
+      console.warn(`⚠️ [API ${requestId}] ${method} ${path} Status: 404`);
     } else if (error.response?.status !== 401) {
       console.error(
-        'API 请求错误:',
-        error.response?.status,
-        error.response?.data || error.message,
-        '请求配置:',
-        error.config,
+        `❌ [API ${requestId}] ${method} ${path} Status: ${error.response?.status || 'network-error'}`,
       );
     }
     return Promise.reject(error);

--- a/app/login/index.tsx
+++ b/app/login/index.tsx
@@ -21,7 +21,6 @@ export default function LoginScreen() {
   const borderColor = Colors[colorScheme].border;
 
   const handleCookies = async (web_cookie: string) => {
-    console.log(web_cookie, '1111');
     // 关键：只有当包含 z_c0 (登录 Token) 时才认为是有效的登录 Cookie
     // 获取 httpOnly cookie，webview 注入 js 是不行的，需要原生支持
     try {


### PR DESCRIPTION
## Summary

- disable React Native's automatic credential injection for signed Zhihu API requests
- ensure iOS sends the same explicit Cookie value used to generate X-ZSE-96
- redact Cookie and Axios request configuration from API/login logs

## Root cause

React Native iOS defaults XHR `withCredentials` to true. `RCTNetworking` first loads cookies from `NSHTTPCookieStorage`, then appends the explicit `Cookie` header set by the Axios interceptor. Duplicate or stale cookie values can make the server-side `d_c0` differ from the value used for X-ZSE-96 signing, causing the member answers/articles endpoints to return 403. Android's OkHttp path handles these headers differently.

## Verification

- `./node_modules/.bin/tsc --noEmit`
- `npm run test:rich-content` (15 passed)
- `./node_modules/.bin/biome check api/client.ts app/login/index.tsx`
- confirmed on iOS by the reporter

Closes #21