### PR TITLE
fix: 修复用户主页、关注状态与账号会话问题

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -1,7 +1,7 @@
 import CookieManager from '@react-native-cookies/cookies';
 import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
-import { useAuthStore } from '@/store/useAuthStore';
+import { shouldImportLegacySession, useAuthStore } from '@/store/useAuthStore';
 import { useVerificationStore } from '@/store/useVerificationStore';
 import { signRequest96, ZSE_VERSION } from './zse96/index';
 
@@ -46,16 +46,32 @@ function getXsrf(cookie: string) {
   return match ? match[1] : null;
 }
 
+function hasAuthenticationCookie(cookie: string) {
+  return /(?:^|;\s*)z_c0=/.test(cookie);
+}
+
 apiClient.interceptors.request.use(async (config) => {
   const requestId = getRequestId(config);
   console.log(
     `🌐 [API ${requestId}] ${config.method?.toUpperCase()} ${getSafePath(config.url)}`,
   );
-  // 优先从 AuthStore 获取，如果没有再尝试从 SecureStore (向下兼容)
-  let cookie =
-    useAuthStore.getState().cookies ||
-    (await SecureStore.getItemAsync('user_cookies')) ||
-    '';
+  // The file-backed auth store is the source of truth. Waiting for hydration
+  // prevents a stale legacy SecureStore cookie from winning during startup.
+  if (!useAuthStore.persist.hasHydrated()) {
+    await useAuthStore.persist.rehydrate();
+  }
+
+  // A hydrated guest state is authoritative. Legacy cookie stores are read
+  // only when no file-backed auth state has ever existed on this install.
+  let cookie = useAuthStore.getState().cookies || '';
+  const shouldImportLegacyCookie = !cookie && shouldImportLegacySession();
+
+  if (shouldImportLegacyCookie) {
+    cookie = (await SecureStore.getItemAsync('user_cookies')) || '';
+    if (cookie) {
+      useAuthStore.getState().setCookies(cookie);
+    }
+  }
 
   if (!cookie) {
     try {
@@ -64,12 +80,27 @@ apiClient.interceptors.request.use(async (config) => {
         true,
       );
       if (nativeCookies) {
-        cookie = Object.entries(nativeCookies)
+        const nativeCookie = Object.entries(nativeCookies)
           .map(([name, c]) => `${name}=${c.value}`)
           .join('; ');
+        // Anonymous cookies are required by the guest feed. An authenticated
+        // native cookie is authoritative only during first-install migration.
+        if (
+          shouldImportLegacyCookie ||
+          !hasAuthenticationCookie(nativeCookie)
+        ) {
+          cookie = nativeCookie;
+          if (
+            cookie &&
+            shouldImportLegacyCookie &&
+            hasAuthenticationCookie(cookie)
+          ) {
+            useAuthStore.getState().setCookies(cookie);
+          }
+        }
       }
-    } catch (e) {
-      console.warn('获取原生 cookie 失败', e);
+    } catch {
+      console.warn('获取原生 Cookie 失败');
     }
   }
 

--- a/api/zhihu/feed.ts
+++ b/api/zhihu/feed.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useSettingsStore } from '@/store/useSettingsStore';
 import apiClient from '../client';
@@ -15,22 +16,30 @@ export interface FeedTopic {
   name: string;
 }
 
+export interface FeedContentSegment {
+  type: string;
+  content?: string;
+  url?: string;
+  data_draft_title?: string;
+  data_draft_cover?: string;
+}
+
 export interface FeedItem {
   id: string;
   isIdStable?: boolean;
-  title: any;
+  title: ReactNode;
   questionId?: string;
   actionText?: string;
   author: FeedAuthor;
-  excerpt: any;
-  content: string;
+  excerpt: ReactNode;
+  content?: string | FeedContentSegment[];
   image: string | null;
   voteCount: number;
   commentCount: number;
   favlistsCount?: number;
   voted: number;
-  type: 'answers' | 'articles' | 'pins' | 'questions';
-  topics: FeedTopic[];
+  type: 'answers' | 'articles' | 'pins' | 'questions' | 'videos';
+  topics?: FeedTopic[];
   rank?: number;
   hotValue?: string;
   titleString?: string;
@@ -60,7 +69,7 @@ export interface RawFeedTarget {
   type: string;
   title?: string;
   excerpt?: string;
-  content?: any;
+  content?: string | FeedContentSegment[];
   thumbnail?: string;
   content_img?: string[];
   voteup_count?: number;
@@ -163,6 +172,8 @@ export interface RawFeedItem {
     thumbnail?: string;
   }>;
   image_url?: string;
+  detail_text?: string;
+  debut?: boolean;
   // Hot List specific fields
   card_id?: string;
   card_label?: {
@@ -190,7 +201,7 @@ export const FEED_URLS = {
   recommend: 'https://www.zhihu.com/api/v3/feed/topstory/recommend?limit=10',
   local: 'zhihu://local-feed',
   hot: 'https://www.zhihu.com/api/v3/feed/topstory/hot-lists/total?limit=50',
-};
+} as const;
 
 export const getFeed = async (url: string): Promise<ZhihuFeedResponse> => {
   let finalUrl = url;
@@ -209,12 +220,13 @@ export const getFeed = async (url: string): Promise<ZhihuFeedResponse> => {
   if (url === 'zhihu://local-feed') {
     // 1. Fetch sections to find the local section ID
     try {
-      const sectionsRes = await apiClient.get(
-        'https://api.zhihu.com/feed-root/sections/query/v2',
-      );
+      const sectionsRes = await apiClient.get<{
+        data?: Array<{ section_id?: string; section_name?: string }>;
+      }>('https://api.zhihu.com/feed-root/sections/query/v2');
       const sections = sectionsRes.data?.data || [];
       const localSection = sections.find(
-        (s: any) => s.section_name?.includes('同城') || s.section_id,
+        (section) =>
+          section.section_name?.includes('同城') || section.section_id,
       );
 
       if (localSection?.section_id) {
@@ -227,8 +239,8 @@ export const getFeed = async (url: string): Promise<ZhihuFeedResponse> => {
       } else {
         throw new Error('未找到同城版块');
       }
-    } catch (err) {
-      console.warn('获取同城版块失败，回退到推荐流', err);
+    } catch {
+      console.warn('获取同城版块失败，回退到推荐流');
       finalUrl = FEED_URLS.recommend;
     }
   } else if (url.startsWith('zhihu://local-feed/')) {

--- a/api/zhihu/me.ts
+++ b/api/zhihu/me.ts
@@ -1,3 +1,4 @@
+import type { ZhihuMemberRelation, ZhihuPaging } from '@/types/zhihu';
 import apiClient from '../client';
 
 export interface ZhihuMeInfo {
@@ -21,14 +22,14 @@ export interface ZhihuMeInfo {
     is_vip: boolean;
     vip_type: number;
     rename_days: string;
-    entrance_v2: any;
+    entrance_v2: unknown;
     rename_frequency: number;
     rename_await_days: number;
   };
   kvip_info: {
     is_vip: boolean;
   };
-  account_status: any[];
+  account_status: unknown[];
   is_force_renamed: boolean;
   is_destroy_waiting: boolean;
   answer_count: number;
@@ -45,7 +46,7 @@ export interface ZhihuMeInfo {
   line_comment_only_count: number;
   following_question_count: number;
   available_medals_count: number;
-  org_verify_status: any;
+  org_verify_status: unknown;
   uid: string;
   email: string;
   renamed_fullname: string;
@@ -61,7 +62,7 @@ export interface ZhihuMeInfo {
   has_add_baike_summary_permission: boolean;
   editor_info: string[];
   available_message_types: string[];
-  ai_assistant_info: any;
+  ai_assistant_info: unknown;
   can_create_sub_account: boolean;
   account_type: number;
   sub_account_control_status: number;
@@ -78,11 +79,14 @@ export const getMyLikes = async (
   type: 'answers' | 'articles',
   limit = 20,
   offset = 0,
-) => {
+): Promise<{ data: ZhihuMemberRelation[]; paging: ZhihuPaging }> => {
   const endpoint = type === 'answers' ? 'voted_answers' : 'voted_articles';
   const include =
     'data[*].content,voteup_count,comment_count,created_time,updated_time,excerpt,question.title,relationship.voting';
-  const res = await apiClient.get(
+  const res = await apiClient.get<{
+    data: ZhihuMemberRelation[];
+    paging: ZhihuPaging;
+  }>(
     `/members/me/${endpoint}?limit=${limit}&offset=${offset}&include=${include}`,
   );
   return res.data;

--- a/api/zhihu/member.ts
+++ b/api/zhihu/member.ts
@@ -1,22 +1,90 @@
+import type {
+  ZhihuAuthor,
+  ZhihuMemberRelation,
+  ZhihuPaging,
+} from '@/types/zhihu';
 import apiClient from '../client';
 
 export const MEMBER_INCLUDE =
   'url_token,answer_count,articles_count,question_count,pins_count,follower_count,following_count,headline,cover_url,description,voteup_count,thanked_count,favorited_count,is_following,mutual_followees_count';
 
-export const getMember = async (id: string | number, include?: string) => {
-  const res = await apiClient.get(
+const MEMBER_FALLBACK_INCLUDE =
+  'id,url_token,name,avatar_url,follower_count,following_count,headline,cover_url,description,answer_count,articles_count,question_count,pins_count,voteup_count,is_following,mutual_followees_count';
+
+export interface ZhihuMember extends ZhihuAuthor {
+  answer_count?: number;
+  articles_count?: number;
+  question_count?: number;
+  pins_count?: number;
+  follower_count?: number;
+  following_count?: number;
+  cover_url?: string;
+  description?: string;
+  voteup_count?: number;
+  thanked_count?: number;
+  favorited_count?: number;
+  mutual_followees_count?: number;
+}
+
+export interface ZhihuMemberListItem extends ZhihuMember {
+  is_followed?: boolean;
+}
+
+export interface ZhihuListResponse<T> {
+  data: T[];
+  paging: ZhihuPaging;
+}
+
+export interface ZhihuMemberActivity {
+  id?: string | number;
+  target?: ZhihuMemberRelation;
+  type?: string;
+  url?: string;
+}
+
+export interface ZhihuFollowResponse {
+  follower_count?: number;
+}
+
+function getErrorStatus(error: unknown) {
+  if (!error || typeof error !== 'object' || !('response' in error)) {
+    return undefined;
+  }
+  const response = error.response;
+  if (!response || typeof response !== 'object' || !('status' in response)) {
+    return undefined;
+  }
+  return typeof response.status === 'number' ? response.status : undefined;
+}
+
+export const getMember = async (
+  id: string | number,
+  include?: string,
+): Promise<ZhihuMember> => {
+  const res = await apiClient.get<ZhihuMember>(
     `/members/${id}?include=${include || MEMBER_INCLUDE}`,
   );
   return res.data;
+};
+
+export const getMemberWithFallback = async (id: string | number) => {
+  try {
+    return await getMember(id);
+  } catch (error: unknown) {
+    if (getErrorStatus(error) === 403) {
+      return getMember(id, MEMBER_FALLBACK_INCLUDE);
+    }
+    throw error;
+  }
 };
 
 export const getMemberActivities = async (
   id: string | number,
   limit = 20,
   offset = 0,
-) => {
+): Promise<ZhihuListResponse<ZhihuMemberActivity>> => {
   const url = `https://www.zhihu.com/api/v3/moments/${id}/activities?limit=${limit}&offset=${offset}`;
-  const res = await apiClient.get(url, {
+  const res = await apiClient.get<ZhihuListResponse<ZhihuMemberActivity>>(url, {
     headers: {
       'x-api-version': '3.0.40',
     },
@@ -33,19 +101,30 @@ export const getMemberRelations = async (
     include?: string;
     sort_by?: string;
   },
-) => {
+): Promise<ZhihuListResponse<ZhihuMemberRelation>> => {
   const endpoint = `/members/${id}/${type}`;
-  const res = await apiClient.get(endpoint, { params });
+  const res = await apiClient.get<ZhihuListResponse<ZhihuMemberRelation>>(
+    endpoint,
+    { params },
+  );
   return res.data;
 };
 
-export const followMember = async (id: string | number) => {
-  const res = await apiClient.post(`/members/${id}/followers`);
+export const followMember = async (
+  id: string | number,
+): Promise<ZhihuFollowResponse> => {
+  const res = await apiClient.post<ZhihuFollowResponse>(
+    `/members/${id}/followers`,
+  );
   return res.data;
 };
 
-export const unfollowMember = async (id: string | number) => {
-  const res = await apiClient.delete(`/members/${id}/followers`);
+export const unfollowMember = async (
+  id: string | number,
+): Promise<ZhihuFollowResponse> => {
+  const res = await apiClient.delete<ZhihuFollowResponse>(
+    `/members/${id}/followers`,
+  );
   return res.data;
 };
 
@@ -53,10 +132,10 @@ export const getMemberFollowers = async (
   id: string | number,
   limit = 20,
   offset = 0,
-) => {
+): Promise<ZhihuListResponse<ZhihuMemberListItem>> => {
   const include =
     'data[*].answer_count,articles_count,gender,follower_count,is_followed,is_following,badge[?(type=best_answerer)].topics';
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuListResponse<ZhihuMemberListItem>>(
     `/members/${id}/followers?include=${include}&limit=${limit}&offset=${offset}`,
   );
   return res.data;
@@ -66,10 +145,10 @@ export const getMemberFollowing = async (
   id: string | number,
   limit = 20,
   offset = 0,
-) => {
+): Promise<ZhihuListResponse<ZhihuMemberListItem>> => {
   const include =
     'data[*].answer_count,articles_count,gender,follower_count,is_followed,is_following,badge[?(type=best_answerer)].topics';
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuListResponse<ZhihuMemberListItem>>(
     `/members/${id}/followees?include=${include}&limit=${limit}&offset=${offset}`,
   );
   return res.data;
@@ -79,10 +158,10 @@ export const getMemberMutual = async (
   id: string | number,
   limit = 20,
   offset = 0,
-) => {
+): Promise<ZhihuListResponse<ZhihuMemberListItem>> => {
   const include =
     'data[*].answer_count,articles_count,gender,follower_count,is_followed,is_following,badge[?(type=best_answerer)].topics';
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuListResponse<ZhihuMemberListItem>>(
     `/members/${id}/relations/mutuals?include=${include}&limit=${limit}&offset=${offset}`,
   );
   return res.data;

--- a/app.json
+++ b/app.json
@@ -43,9 +43,7 @@
       },
       "predictiveBackGestureEnabled": false,
       "package": "com.huamu013.ZhihuMinusMinus",
-      "permissions": [
-        "REQUEST_INSTALL_PACKAGES"
-      ],
+      "permissions": ["REQUEST_INSTALL_PACKAGES"],
       "intentFilters": [
         {
           "action": "VIEW",
@@ -73,6 +71,16 @@
             {
               "scheme": "https",
               "host": "www.zhihu.com",
+              "pathPrefix": "/zvideo/"
+            },
+            {
+              "scheme": "https",
+              "host": "www.zhihu.com",
+              "pathPrefix": "/video/"
+            },
+            {
+              "scheme": "https",
+              "host": "www.zhihu.com",
               "pathPrefix": "/people/"
             },
             {
@@ -113,6 +121,16 @@
             {
               "scheme": "https",
               "host": "zhihu.com",
+              "pathPrefix": "/zvideo/"
+            },
+            {
+              "scheme": "https",
+              "host": "zhihu.com",
+              "pathPrefix": "/video/"
+            },
+            {
+              "scheme": "https",
+              "host": "zhihu.com",
               "pathPrefix": "/people/"
             },
             {
@@ -131,10 +149,7 @@
               "pathPrefix": "/collection/"
             }
           ],
-          "category": [
-            "BROWSABLE",
-            "DEFAULT"
-          ]
+          "category": ["BROWSABLE", "DEFAULT"]
         },
         {
           "action": "VIEW",
@@ -145,10 +160,7 @@
               "pathPrefix": "/p/"
             }
           ],
-          "category": [
-            "BROWSABLE",
-            "DEFAULT"
-          ]
+          "category": ["BROWSABLE", "DEFAULT"]
         },
         {
           "action": "VIEW",
@@ -192,12 +204,29 @@
               "scheme": "https",
               "host": "oia.zhihu.com",
               "pathPrefix": "/pins/"
+            },
+            {
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/zvideo/"
+            },
+            {
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/zvideos/"
+            },
+            {
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/video/"
+            },
+            {
+              "scheme": "https",
+              "host": "oia.zhihu.com",
+              "pathPrefix": "/videos/"
             }
           ],
-          "category": [
-            "BROWSABLE",
-            "DEFAULT"
-          ]
+          "category": ["BROWSABLE", "DEFAULT"]
         },
         {
           "action": "VIEW",
@@ -206,10 +235,7 @@
               "scheme": "zhihu"
             }
           ],
-          "category": [
-            "BROWSABLE",
-            "DEFAULT"
-          ]
+          "category": ["BROWSABLE", "DEFAULT"]
         }
       ]
     },

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -32,6 +32,7 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
+import type { EdgeInsets } from 'react-native-safe-area-context';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
 // 使用 @ 别名导入组件
@@ -60,7 +61,7 @@ import {
   feedExposureRepository,
 } from '@/storage/feedExposureRepository';
 import { useAuthStore } from '@/store/useAuthStore';
-import { type TabKey, useSettingsStore } from '@/store/useSettingsStore';
+import { useSettingsStore } from '@/store/useSettingsStore';
 import { supportsLocalFeedDedup } from '@/utils/feedDedup';
 import {
   applyFeedFilter,
@@ -94,7 +95,21 @@ const TABS = [
   'profile',
 ] as const;
 type TabType = (typeof TABS)[number];
+type FeedTabType = keyof typeof FEED_URLS;
 type FeedListItem = FeedItem | HotItem | CollapsedGroup;
+
+function isTabType(value: string): value is TabType {
+  return (TABS as readonly string[]).includes(value);
+}
+
+interface TabListHandle {
+  scrollToOffset: (args: { offset: number; animated?: boolean }) => void;
+  refresh?: () => void;
+}
+
+interface FeedListHandle extends TabListHandle {
+  refresh: () => void;
+}
 
 // 隐藏模式下被过滤项不占行，一页内容可能所剩无几甚至为空——列表不足一屏时
 // 用户无法滚动，onEndReached 不会再触发，列表就此卡住。故在该模式下主动补页
@@ -117,18 +132,10 @@ export default function HomeScreen() {
 
   // 动态过滤 Tabs
   const currentTabs = useMemo(() => {
-    return [
-      'following',
-      'recommend',
-      'local',
-      'hot',
-      'daily',
-      'publish',
-      'profile',
-    ].filter((tab) => {
+    return TABS.filter((tab) => {
       if (tab === 'profile') return true;
-      return visibleTabs.includes(tab as any);
-    }) as TabType[];
+      return visibleTabs.includes(tab);
+    });
   }, [visibleTabs]);
 
   const homeTabs = useMemo(() => {
@@ -147,8 +154,8 @@ export default function HomeScreen() {
   // 计算初始页码
   const initialPageIndex = useMemo(() => {
     // 优先考虑 URL 参数中的 tab
-    if (params.tab) {
-      const idx = currentTabs.indexOf(params.tab as TabKey);
+    if (params.tab && isTabType(params.tab)) {
+      const idx = currentTabs.indexOf(params.tab);
       if (idx >= 0) return idx;
     }
     const idx = currentTabs.indexOf(defaultTab);
@@ -193,8 +200,8 @@ export default function HomeScreen() {
 
   // 监听 params.tab 变化并切换页面
   useEffect(() => {
-    if (params.tab) {
-      const idx = currentTabs.indexOf(params.tab as TabKey);
+    if (params.tab && isTabType(params.tab)) {
+      const idx = currentTabs.indexOf(params.tab);
       if (idx >= 0 && idx !== currentPage) {
         pagerRef.current?.setPage(idx);
         setCurrentPage(idx);
@@ -206,7 +213,7 @@ export default function HomeScreen() {
   const [refreshingTabs, setRefreshingTabs] = useState<Record<number, boolean>>(
     {},
   );
-  const listRefs = useRef<any[]>([]);
+  const listRefs = useRef<Array<TabListHandle | null>>([]);
 
   const handleRefreshStateChange = useCallback(
     (pageIndex: number, isRefreshing: boolean) => {
@@ -468,7 +475,9 @@ export default function HomeScreen() {
             <View key={tab} style={{ flex: 1, backgroundColor: 'transparent' }}>
               {!isVisited ? null : tab === 'daily' ? (
                 <DailyList
-                  ref={(el) => (listRefs.current[idx] = el)}
+                  ref={(element) => {
+                    listRefs.current[idx] = element;
+                  }}
                   insets={insets}
                   onScroll={(offset) => handleScrollUpdate(idx, offset)}
                   onRefreshStateChange={(isRefreshing) =>
@@ -478,7 +487,7 @@ export default function HomeScreen() {
               ) : tab === 'publish' ? (
                 <PublishScreen />
               ) : tab === 'profile' ? (
-                <ProfileScreen />
+                <ProfileScreen isActive={isFocused && currentPage === idx} />
               ) : !cookies && tab === 'following' ? (
                 <View style={styles.loginPrompt}>
                   <Text style={styles.loginText} type="secondary">
@@ -486,15 +495,17 @@ export default function HomeScreen() {
                   </Text>
                   <Pressable
                     style={[styles.loginBtn, { backgroundColor: tintColor }]}
-                    onPress={() => router.push('/login' as any)}
+                    onPress={() => router.push('/login')}
                   >
                     <Text style={styles.loginBtnText}>去登录</Text>
                   </Pressable>
                 </View>
               ) : (
                 <FeedList
-                  ref={(el) => (listRefs.current[idx] = el)}
-                  tab={tab as any}
+                  ref={(element) => {
+                    listRefs.current[idx] = element;
+                  }}
+                  tab={tab as FeedTabType}
                   isActive={isFocused && currentPage === idx}
                   insets={insets}
                   guestCookieReady={guestCookieReady}
@@ -657,7 +668,15 @@ function BottomTabIcon({
   size = 24,
   isScrollTop,
   width,
-}: any) {
+}: {
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  onPress: () => void;
+  color: string;
+  size?: number;
+  active?: boolean;
+  isScrollTop?: boolean;
+  width?: number;
+}) {
   // 动画状态
   const scale = useSharedValue(1);
   const opacity = useSharedValue(1);
@@ -701,11 +720,11 @@ function BottomTabIcon({
 
 // FeedList 组件
 const FeedList = React.forwardRef<
-  any,
+  FeedListHandle,
   {
-    tab: TabType;
+    tab: FeedTabType;
     isActive: boolean;
-    insets: any;
+    insets: EdgeInsets;
     guestCookieReady: boolean;
     onScroll?: (offset: number) => void;
     onRefreshStateChange?: (isRefreshing: boolean) => void;
@@ -814,7 +833,7 @@ const FeedList = React.forwardRef<
 
     const [initialFeedCache, setInitialFeedCache] = useState<{
       pages: Array<{ items: FeedListItem[]; nextUrl: string | null }>;
-      pageParams: any[];
+      pageParams: string[];
     } | null>(null);
     const [isCacheCheckDone, setIsCacheCheckDone] = useState(false);
 
@@ -832,7 +851,7 @@ const FeedList = React.forwardRef<
           if (cached && cached.items.length > 0) {
             setInitialFeedCache({
               pages: [{ items: cached.items, nextUrl: cached.nextUrl }],
-              pageParams: [(FEED_URLS as any)[tab]],
+              pageParams: [FEED_URLS[tab]],
             });
           }
         })
@@ -924,13 +943,13 @@ const FeedList = React.forwardRef<
       refetch,
     } = useInfiniteQuery({
       queryKey: ['zhihu-feed', queryAccountKey, tab],
-      queryFn: async ({ pageParam = (FEED_URLS as any)[tab] }) => {
+      queryFn: async ({ pageParam = FEED_URLS[tab] }) => {
         if (!cookies && tab === 'following')
           return { items: [], nextUrl: null };
         try {
           let requestUrl = pageParam as string;
           const isInitialUrl =
-            (requestUrl === (FEED_URLS as any)[tab] ||
+            (requestUrl === FEED_URLS[tab] ||
               requestUrl === 'zhihu://local-feed' ||
               requestUrl.includes('feed/topstory/recommend')) &&
             !requestUrl.includes('action=down');
@@ -939,7 +958,9 @@ const FeedList = React.forwardRef<
             requestUrl = `${requestUrl}${sep}action=up&t=${Date.now()}`;
           }
 
-          console.log(`🌐 [queryFn] Requesting URL: ${requestUrl} (tab=${tab}, isRefreshing=${isRefreshing})`);
+          console.log(
+            `🌐 [queryFn] Requesting URL: ${requestUrl} (tab=${tab}, isRefreshing=${isRefreshing})`,
+          );
           const data = await getFeed(requestUrl);
           const rawItems = data.data || [];
           seedAnswerDetailsFromFeed(queryClient, rawItems);
@@ -960,11 +981,7 @@ const FeedList = React.forwardRef<
           const nextUrl =
             data.paging?.next?.replace('http://', 'https://') ?? null;
 
-          if (
-            launchCacheContext &&
-            isInitialUrl &&
-            items.length > 0
-          ) {
+          if (launchCacheContext && isInitialUrl && items.length > 0) {
             void feedCacheRepository
               .saveFeedCache(launchCacheContext, items, nextUrl)
               .catch((err) => console.warn('保存启动 Feed 缓存失败', err));
@@ -974,11 +991,11 @@ const FeedList = React.forwardRef<
             items,
             nextUrl,
           };
-        } catch (_e: any) {
+        } catch {
           return { items: [], nextUrl: null };
         }
       },
-      initialPageParam: (FEED_URLS as any)[tab],
+      initialPageParam: FEED_URLS[tab],
       getNextPageParam: (lastPage) => lastPage.nextUrl,
       initialData: initialFeedCache ?? undefined,
       staleTime: launchCacheContext && initialFeedCache ? 5 * 60 * 1000 : 0,
@@ -1009,9 +1026,7 @@ const FeedList = React.forwardRef<
           }
         }
         const initialParam =
-          tab === 'local'
-            ? 'zhihu://local-feed'
-            : (FEED_URLS as any)[tab];
+          tab === 'local' ? 'zhihu://local-feed' : FEED_URLS[tab];
         await refreshInfiniteQuery(
           queryClient,
           ['zhihu-feed', queryAccountKey, tab],
@@ -1127,7 +1142,7 @@ const FeedList = React.forwardRef<
     }, [isActive, localDedupEnabled, recentExposureKeys]);
 
     React.useImperativeHandle(ref, () => ({
-      scrollToOffset: (args: any) => flashListRef.current?.scrollToOffset(args),
+      scrollToOffset: (args) => flashListRef.current?.scrollToOffset(args),
       refresh: handleRefresh,
     }));
 
@@ -1275,7 +1290,12 @@ function parseFollowingData(item: RawFeedItem): FeedItem | null {
         target.author?.avatar_url ||
         'https://picx.zhimg.com/v2-abed1a8c04700ba7d72b45195223e0ff_l.jpg',
     },
-    excerpt: target.excerpt || target.content?.[0]?.content || '',
+    excerpt:
+      target.excerpt ||
+      (Array.isArray(target.content)
+        ? target.content[0]?.content
+        : target.content) ||
+      '',
     content: target.content || '',
     image:
       target.thumbnail ||
@@ -1288,7 +1308,10 @@ function parseFollowingData(item: RawFeedItem): FeedItem | null {
       target.favorite_count || target.reaction?.statistics?.favorites || 0,
     voted: target.relationship?.voting || 0,
     type: appType,
-    topics: target.topics?.map((t: any) => ({ id: t.id, name: t.name })) || [],
+    topics: target.topics?.map((topic) => ({
+      id: topic.id,
+      name: topic.name,
+    })),
   };
 }
 
@@ -1354,7 +1377,12 @@ function parseRecommendData(item: RawFeedItem): FeedItem | null {
         'https://picx.zhimg.com/v2-abed1a8c04700ba7d72b45195223e0ff_l.jpg',
       headline: target.author?.headline || '',
     },
-    excerpt: target.excerpt || target.content?.[0]?.content || '',
+    excerpt:
+      target.excerpt ||
+      (Array.isArray(target.content)
+        ? target.content[0]?.content
+        : target.content) ||
+      '',
     content: target.content || '',
     image:
       target.thumbnail ||
@@ -1370,7 +1398,10 @@ function parseRecommendData(item: RawFeedItem): FeedItem | null {
       0,
     voted: target.relationship?.voting || 0,
     type: appType,
-    topics: target.topics?.map((t: any) => ({ id: t.id, name: t.name })) || [],
+    topics: target.topics?.map((topic) => ({
+      id: topic.id,
+      name: topic.name,
+    })),
     // 本地过滤信号：实测推荐流可用字段（详见 utils/feedFilter.ts）
     // 盐选双信号取或：answer_type === 'PAID' 或 paid_info != null。
     // 大小写按接口而异——实测游客推荐流返回小写 `normal`，话题流返回大写
@@ -1393,8 +1424,8 @@ function parseRecommendData(item: RawFeedItem): FeedItem | null {
   };
 }
 
-function parseHotData(item: any, index: number): HotItem {
-  const target = (item.target || item) as any;
+function parseHotData(item: RawFeedItem, index: number): HotItem {
+  const target = item.target || (item as unknown as RawFeedTarget);
   const questionId =
     target.link?.url?.split('/').pop() || target.url?.split('/').pop() || '';
 

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,10 +2,10 @@ import { Ionicons } from '@expo/vector-icons';
 import CookieManager from '@react-native-cookies/cookies';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
-import { useFocusEffect, useRouter } from 'expo-router';
-import * as SecureStore from 'expo-secure-store';
+import { useRouter } from 'expo-router';
 import React from 'react';
 import {
+  ActivityIndicator,
   Alert,
   Image,
   Modal,
@@ -14,8 +14,10 @@ import {
   ScrollView,
   Switch,
 } from 'react-native';
-import { getMe, getMember } from '@/api/zhihu';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { getMe, getMemberWithFallback } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
@@ -23,9 +25,15 @@ import { useAuthStore } from '@/store/useAuthStore';
 import { useSettingsStore } from '@/store/useSettingsStore';
 import { useThemeStore } from '@/store/useThemeStore';
 import { useVerificationStore } from '@/store/useVerificationStore';
+import { syncNativeSessionCookies } from '@/utils/authSession';
 
-export default function ProfileScreen() {
+interface ProfileScreenProps {
+  isActive?: boolean;
+}
+
+export default function ProfileScreen({ isActive = true }: ProfileScreenProps) {
   const colorScheme = useColorScheme();
+  const insets = useSafeAreaInsets();
   const router = useRouter();
   const queryClient = useQueryClient();
   const { isDark, toggleTheme } = useThemeStore();
@@ -44,84 +52,116 @@ export default function ProfileScreen() {
   } = useAuthStore();
 
   const [accountModalVisible, setAccountModalVisible] = React.useState(false);
+  const [sessionChanging, setSessionChanging] = React.useState(false);
+  const sessionChangeInFlight = React.useRef(false);
 
   const {
     data: me,
     isLoading: isMeLoading,
+    isFetching: isMeFetching,
+    isError: isMeError,
     refetch: refetchMe,
   } = useQuery({
     queryKey: ['me'],
-    queryFn: () => getMe(),
+    queryFn: async () => {
+      const fetchedMe = await getMe();
+      const authState = useAuthStore.getState();
+      // Complete the one-time SecureStore migration as a normal account once
+      // the authenticated member payload is available.
+      if (cookies && authState.cookies === cookies && !authState.me) {
+        authState.addAccount(cookies, fetchedMe);
+      }
+      return fetchedMe;
+    },
     enabled: !!cookies,
   });
 
+  const memberId = me?.url_token || me?.id;
+
   const {
     data: member,
-    isLoading: isMemberLoading,
-    refetch: refetchMember,
+    isFetching: isMemberFetching,
+    isError: isMemberError,
   } = useQuery({
-    queryKey: ['me-detail', me?.url_token || me?.id],
-    queryFn: () => getMember((me?.url_token || me?.id) as string),
-    enabled: !!(me?.url_token || me?.id),
+    queryKey: ['me-detail', memberId],
+    queryFn: () => getMemberWithFallback(memberId as string),
+    enabled: !!memberId,
   });
 
   const profile = member || me;
 
-  const isLoading = isMeLoading || isMemberLoading;
-  const refetch = React.useCallback(() => {
-    refetchMe();
-    refetchMember();
-  }, [refetchMe, refetchMember]);
+  const isRefreshing = isMeFetching || isMemberFetching;
+  const refreshProfile = React.useCallback(async () => {
+    if (!cookies) return;
+    const meResult = await refetchMe();
+    const refreshedMemberId = meResult.data?.url_token || meResult.data?.id;
+    if (!refreshedMemberId) return;
+    try {
+      await queryClient.fetchQuery({
+        queryKey: ['me-detail', refreshedMemberId],
+        queryFn: () => getMemberWithFallback(refreshedMemberId),
+      });
+    } catch {
+      // The member query exposes its own retry UI below.
+    }
+  }, [cookies, queryClient, refetchMe]);
 
   const unreadCount =
-    (profile?.default_notifications_count || 0) +
-    (profile?.follow_notifications_count || 0) +
-    (profile?.vote_thank_notifications_count || 0);
+    (me?.default_notifications_count || 0) +
+    (me?.follow_notifications_count || 0) +
+    (me?.vote_thank_notifications_count || 0);
 
-  useFocusEffect(
-    React.useCallback(() => {
-      if (cookies) refetch();
-    }, [cookies, refetch]),
+  const wasActive = React.useRef(isActive);
+  React.useEffect(() => {
+    if (isActive && !wasActive.current && cookies) {
+      void refreshProfile();
+    }
+    wasActive.current = isActive;
+  }, [cookies, isActive, refreshProfile]);
+
+  const syncSessionWithFeedback = React.useCallback(
+    async (targetCookies: string | null) => {
+      try {
+        await syncNativeSessionCookies(targetCookies);
+      } catch {
+        Alert.alert(
+          '会话同步失败',
+          '账号已经切换，但网页登录状态未能同步。请稍后重试或重新登录。',
+        );
+      }
+    },
+    [],
   );
 
-  // 封装：同步原生层的 Session 状态（SecureStore 和 CookieManager）
-  const syncNativeSession = async (cookieString: string | null) => {
-    if (cookieString) {
-      try {
-        if (cookieString.length < 2000) {
-          await SecureStore.setItemAsync('user_cookies', cookieString);
-        }
-      } catch (e) {
-        console.warn('⚠️ 无法同步 Cookie 到 SecureStore:', e);
-      }
-      await CookieManager.clearAll(true);
-      const cookiePairs = cookieString.split(';');
-      for (const pair of cookiePairs) {
-        const trimmedPair = pair.trim();
-        if (!trimmedPair) continue;
-        const equalIndex = trimmedPair.indexOf('=');
-        if (equalIndex > 0) {
-          const name = trimmedPair.substring(0, equalIndex);
-          const value = trimmedPair.substring(equalIndex + 1);
-          if (name && value) {
-            await CookieManager.set(
-              'https://www.zhihu.com',
-              {
-                name,
-                value,
-                domain: '.zhihu.com',
-                path: '/',
-              },
-              true,
-            );
-          }
-        }
-      }
-    } else {
-      await SecureStore.deleteItemAsync('user_cookies');
-      await CookieManager.clearAll(true);
+  const performLogout = React.useCallback(async () => {
+    if (sessionChangeInFlight.current) return;
+    sessionChangeInFlight.current = true;
+    setSessionChanging(true);
+    useVerificationStore.getState().hide();
+
+    const remainingAccounts = accounts.filter(
+      (_, index) => index !== activeAccountIndex,
+    );
+    const nextCookies = remainingAccounts[0]?.cookies ?? null;
+
+    logout();
+    queryClient.clear();
+    setAccountModalVisible(false);
+    await syncSessionWithFeedback(nextCookies);
+
+    sessionChangeInFlight.current = false;
+    setSessionChanging(false);
+    if (remainingAccounts.length === 0) {
+      router.replace('/login');
     }
-  };
+  }, [
+    accounts,
+    activeAccountIndex,
+    logout,
+    queryClient,
+    router,
+    syncSessionWithFeedback,
+  ]);
 
   const handleLogout = () => {
     Alert.alert('退出登录', '确定要退出当前账号吗喵？', [
@@ -129,47 +169,33 @@ export default function ProfileScreen() {
       {
         text: '确定退出',
         style: 'destructive',
-        onPress: async () => {
-          useVerificationStore.getState().hide();
-
-          const remainingAccounts = accounts.filter(
-            (_, i) => i !== activeAccountIndex,
-          );
-
-          // 核心：注销时如果要切换到下一个账号，必须同步原生状态
-          if (remainingAccounts.length > 0) {
-            await syncNativeSession(remainingAccounts[0].cookies);
-          } else {
-            await syncNativeSession(null);
-          }
-
-          logout();
-          queryClient.clear();
-
-          if (remainingAccounts.length === 0) {
-            router.replace('/login');
-          }
-        },
+        onPress: () => void performLogout(),
       },
     ]);
   };
 
   const handleSwitchAccount = async (index: number) => {
-    if (index === activeAccountIndex) return;
+    if (index === activeAccountIndex || sessionChangeInFlight.current) return;
 
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     useVerificationStore.getState().hide();
+    sessionChangeInFlight.current = true;
+    setSessionChanging(true);
 
-    if (index === -1) {
-      await syncNativeSession(null);
-    } else {
-      const targetAccount = accounts[index];
-      await syncNativeSession(targetAccount.cookies);
+    const targetCookies: string | null =
+      index === -1 ? null : (accounts[index]?.cookies ?? null);
+    if (index !== -1 && !targetCookies) {
+      sessionChangeInFlight.current = false;
+      setSessionChanging(false);
+      return;
     }
 
     switchAccount(index);
     queryClient.clear();
     setAccountModalVisible(false);
+    await syncSessionWithFeedback(targetCookies);
+    sessionChangeInFlight.current = false;
+    setSessionChanging(false);
   };
 
   const handleRemoveAccount = (index: number) => {
@@ -179,10 +205,9 @@ export default function ProfileScreen() {
       {
         text: '确定移除',
         style: 'destructive',
-        onPress: async () => {
+        onPress: () => {
           if (index === activeAccountIndex) {
-            // 如果移除的是当前账号，走注销流程
-            handleLogout();
+            void performLogout();
           } else {
             removeAccount(index);
           }
@@ -192,15 +217,20 @@ export default function ProfileScreen() {
   };
 
   const handleAddAccount = async () => {
+    if (sessionChangeInFlight.current) return;
     setAccountModalVisible(false);
     // When adding account, we don't clear current store yet,
     // just navigate to login. Login will overwrite cookies.
-    await CookieManager.clearAll(true);
-    router.push('/login');
+    try {
+      await CookieManager.clearAll(true);
+      router.push('/login');
+    } catch {
+      Alert.alert('无法添加账号', '清理网页登录状态失败，请稍后重试。');
+    }
   };
 
   const onToggleTheme = () => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     toggleTheme();
   };
 
@@ -209,14 +239,18 @@ export default function ProfileScreen() {
       className="flex-1"
       refreshControl={
         <RefreshControl
-          refreshing={isLoading}
-          onRefresh={refetch}
+          refreshing={isRefreshing}
+          onRefresh={() => void refreshProfile()}
           tintColor={accentColor}
         />
       }
     >
       {/* 顶部用户信息区 */}
-      <View type="surface" className="pt-[60px] px-5 pb-5 rounded-b-[24px]">
+      <View
+        type="surface"
+        className="px-5 pb-5 rounded-b-[24px]"
+        style={{ paddingTop: insets.top + 20 }}
+      >
         {me ? (
           <Pressable
             className="flex-row items-center mb-[25px]"
@@ -238,6 +272,16 @@ export default function ProfileScreen() {
             </View>
             <Ionicons name="chevron-forward" size={20} color="#ccc" />
           </Pressable>
+        ) : cookies && isMeLoading ? (
+          <View className="h-24 items-center justify-center bg-transparent">
+            <ActivityIndicator color={accentColor} />
+          </View>
+        ) : cookies && isMeError ? (
+          <QueryErrorView
+            compact
+            message="个人资料加载失败"
+            onRetry={() => void refreshProfile()}
+          />
         ) : (
           <Pressable
             className="flex-row items-center mb-[25px]"
@@ -261,18 +305,24 @@ export default function ProfileScreen() {
             count={profile?.answer_count || 0}
             label="回答"
             onPress={() =>
-              profile && router.push(`/user/${profile.url_token || profile.id}`)
+              profile &&
+              router.push(
+                `/user/${profile.url_token || profile.id}?tab=answers`,
+              )
             }
           />
           <StatItem
             count={profile?.articles_count || 0}
             label="文章"
             onPress={() =>
-              profile && router.push(`/user/${profile.url_token || profile.id}`)
+              profile &&
+              router.push(
+                `/user/${profile.url_token || profile.id}?tab=articles`,
+              )
             }
           />
           <StatItem
-            count={profile?.following_count || 0}
+            count={member?.following_count || 0}
             label="关注"
             onPress={() =>
               profile &&
@@ -280,7 +330,7 @@ export default function ProfileScreen() {
             }
           />
           <StatItem
-            count={profile?.follower_count || 0}
+            count={member?.follower_count || 0}
             label="粉丝"
             onPress={() =>
               profile &&
@@ -288,6 +338,16 @@ export default function ProfileScreen() {
             }
           />
         </View>
+        {me && isMemberError ? (
+          <Pressable
+            className="items-center mt-3 bg-transparent"
+            onPress={() => void refreshProfile()}
+          >
+            <Text type="secondary" className="text-xs">
+              详细统计加载失败，点此重试
+            </Text>
+          </Pressable>
+        ) : null}
       </View>
 
       {/* 我的资产 */}
@@ -296,13 +356,13 @@ export default function ProfileScreen() {
           icon="bookmark-outline"
           title="我的收藏"
           color="#ff9800"
-          onPress={() => router.push('/collections' as any)}
+          onPress={() => router.push('/collections')}
         />
         <MenuItem
           icon="time-outline"
           title="最近浏览"
           color="#2196f3"
-          onPress={() => router.push('/history' as any)}
+          onPress={() => router.push('/history')}
         />
       </View>
 
@@ -338,19 +398,19 @@ export default function ProfileScreen() {
           icon="color-palette-outline"
           title="外观与定制"
           color={accentColor}
-          onPress={() => router.push('/settings/appearance' as any)}
+          onPress={() => router.push('/settings/appearance')}
         />
         <MenuItem
           icon="filter-outline"
           title="过滤与推荐"
           color={accentColor}
-          onPress={() => router.push('/settings/filter' as any)}
+          onPress={() => router.push('/settings/filter')}
         />
 
         <MenuItem
           icon="notifications-outline"
           title="消息通知"
-          onPress={() => router.push('/notifications' as any)}
+          onPress={() => router.push('/notifications')}
           right={
             unreadCount > 0 ? (
               <View className="flex-row items-center bg-transparent">
@@ -367,7 +427,7 @@ export default function ProfileScreen() {
             icon="chatbubbles-outline"
             title="我的私信"
             color="#4caf50"
-            onPress={() => router.push('/inbox' as any)}
+            onPress={() => router.push('/inbox')}
           />
         )}
         <MenuItem
@@ -395,6 +455,7 @@ export default function ProfileScreen() {
         <Pressable
           className="mt-[30px] py-[15px] items-center"
           onPress={handleLogout}
+          disabled={sessionChanging}
         >
           <Text className="text-[#ff4d4f] text-base font-semibold">
             退出账号
@@ -411,10 +472,11 @@ export default function ProfileScreen() {
         animationType="slide"
         onRequestClose={() => setAccountModalVisible(false)}
       >
-        <Pressable
-          className="flex-1 justify-end bg-black/50"
-          onPress={() => setAccountModalVisible(false)}
-        >
+        <View className="flex-1 justify-end bg-black/50">
+          <Pressable
+            className="absolute inset-0"
+            onPress={() => setAccountModalVisible(false)}
+          />
           <View
             type="surface"
             className="rounded-t-[24px] px-5 pt-3 pb-8"
@@ -428,11 +490,12 @@ export default function ProfileScreen() {
             <ScrollView className="bg-transparent">
               {accounts.map((account, index) => (
                 <View
-                  key={account.me?.id || index}
+                  key={account.me.id}
                   className="flex-row items-center bg-transparent"
                 >
                   <Pressable
                     onPress={() => handleSwitchAccount(index)}
+                    disabled={sessionChanging}
                     className="flex-row items-center py-4 flex-1 border-b border-gray-100 dark:border-gray-800 bg-transparent"
                   >
                     <Image
@@ -478,6 +541,7 @@ export default function ProfileScreen() {
                   </Pressable>
                   <Pressable
                     onPress={() => handleRemoveAccount(index)}
+                    disabled={sessionChanging}
                     className="pl-4 py-4"
                   >
                     <Ionicons name="trash-outline" size={20} color="#ff4d4f" />
@@ -489,6 +553,7 @@ export default function ProfileScreen() {
               <View className="flex-row items-center bg-transparent">
                 <Pressable
                   onPress={() => handleSwitchAccount(-1)}
+                  disabled={sessionChanging}
                   className="flex-row items-center py-4 flex-1 border-b border-gray-100 dark:border-gray-800 bg-transparent"
                 >
                   <View className="w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-800 justify-center items-center">
@@ -542,6 +607,7 @@ export default function ProfileScreen() {
 
               <Pressable
                 onPress={handleAddAccount}
+                disabled={sessionChanging}
                 className="flex-row items-center py-5 bg-transparent"
               >
                 <View className="w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-800 justify-center items-center">
@@ -558,13 +624,19 @@ export default function ProfileScreen() {
               <Text className="text-base font-bold">取消</Text>
             </Pressable>
           </View>
-        </Pressable>
+        </View>
       </Modal>
     </ScrollView>
   );
 }
 
-function StatItem({ count, label, onPress }: any) {
+interface StatItemProps {
+  count: number;
+  label: string;
+  onPress?: () => void;
+}
+
+function StatItem({ count, label, onPress }: StatItemProps) {
   return (
     <Pressable
       onPress={onPress}
@@ -579,7 +651,21 @@ function StatItem({ count, label, onPress }: any) {
   );
 }
 
-function MenuItem({ icon, title, color = '#666', right, onPress }: any) {
+interface MenuItemProps {
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  title: string;
+  color?: string;
+  right?: React.ReactNode;
+  onPress: () => void;
+}
+
+function MenuItem({
+  icon,
+  title,
+  color = '#666',
+  right,
+  onPress,
+}: MenuItemProps) {
   return (
     <BouncyButton
       onPress={onPress}

--- a/app/guest/detail.tsx
+++ b/app/guest/detail.tsx
@@ -65,16 +65,28 @@ export default function GuestDetailScreen() {
   const isArticle = item.type === 'articles';
   const isPin = item.type === 'pins';
   const isAnswer = item.type === 'answers';
+  const isVideo = item.type === 'videos';
+  const isQuestion = item.type === 'questions';
 
-  const typeLabel = isArticle
-    ? '专栏文章'
+  const typeLabel = isVideo
+    ? '知乎视频'
+    : isArticle
+      ? '专栏文章'
+      : isPin
+        ? '精选想法'
+        : isAnswer
+          ? '知乎回答'
+          : '热门问题';
+
+  const routeType = isArticle
+    ? 'article'
     : isPin
-      ? '精选想法'
-      : isAnswer
-        ? '知乎回答'
-        : '热门问题';
-
-  const routeType = isArticle ? 'article' : isPin ? 'pin' : 'answer';
+      ? 'pin'
+      : isVideo
+        ? 'video'
+        : isQuestion
+          ? 'question'
+          : 'answer';
 
   const navigateToComments = () => {
     router.push(
@@ -215,25 +227,27 @@ export default function GuestDetailScreen() {
                   </Text>
                 </View>
               )}
-              {item.commentCount !== undefined && item.commentCount > 0 && (
-                <BouncyButton
-                  onPress={navigateToComments}
-                  className="flex-row items-center px-3 py-1.5 rounded-full"
-                  style={{ backgroundColor: `${secondaryTextColor}08` }}
-                >
-                  <Ionicons
-                    name="chatbubble-ellipses-outline"
-                    size={14}
-                    color={secondaryTextColor}
-                  />
-                  <Text
-                    className="text-xs font-semibold ml-1"
-                    style={{ color: secondaryTextColor }}
+              {!isVideo &&
+                item.commentCount !== undefined &&
+                item.commentCount > 0 && (
+                  <BouncyButton
+                    onPress={navigateToComments}
+                    className="flex-row items-center px-3 py-1.5 rounded-full"
+                    style={{ backgroundColor: `${secondaryTextColor}08` }}
                   >
-                    {item.commentCount} 评论
-                  </Text>
-                </BouncyButton>
-              )}
+                    <Ionicons
+                      name="chatbubble-ellipses-outline"
+                      size={14}
+                      color={secondaryTextColor}
+                    />
+                    <Text
+                      className="text-xs font-semibold ml-1"
+                      style={{ color: secondaryTextColor }}
+                    >
+                      {item.commentCount} 评论
+                    </Text>
+                  </BouncyButton>
+                )}
             </View>
           )}
 
@@ -252,7 +266,12 @@ export default function GuestDetailScreen() {
           <View className="px-5 mt-3 bg-transparent">
             {item.content ? (
               <ZhihuContent
-                content={item.content}
+                content={
+                  typeof item.content === 'string' ? item.content : undefined
+                }
+                contentArray={
+                  Array.isArray(item.content) ? item.content : undefined
+                }
                 objectId={item.id}
                 type={isArticle ? 'article' : isPin ? 'pin' : 'answer'}
                 useNative={true}
@@ -270,31 +289,33 @@ export default function GuestDetailScreen() {
           </View>
 
           {/* 4.5 查看全部评论大按钮 */}
-          {item.commentCount !== undefined && item.commentCount > 0 && (
-            <View className="px-5 mt-6 mb-2 bg-transparent">
-              <BouncyButton
-                onPress={navigateToComments}
-                className="w-full h-12 rounded-xl flex-row items-center justify-center border"
-                style={{
-                  borderColor: tintColor,
-                  backgroundColor: `${tintColor}05`,
-                }}
-              >
-                <Ionicons
-                  name="chatbubble-ellipses-outline"
-                  size={16}
-                  color={tintColor}
-                  style={{ marginRight: 6 }}
-                />
-                <Text
-                  className="font-bold text-[14px]"
-                  style={{ color: tintColor }}
+          {!isVideo &&
+            item.commentCount !== undefined &&
+            item.commentCount > 0 && (
+              <View className="px-5 mt-6 mb-2 bg-transparent">
+                <BouncyButton
+                  onPress={navigateToComments}
+                  className="w-full h-12 rounded-xl flex-row items-center justify-center border"
+                  style={{
+                    borderColor: tintColor,
+                    backgroundColor: `${tintColor}05`,
+                  }}
                 >
-                  查看全部 {item.commentCount} 条评论
-                </Text>
-              </BouncyButton>
-            </View>
-          )}
+                  <Ionicons
+                    name="chatbubble-ellipses-outline"
+                    size={16}
+                    color={tintColor}
+                    style={{ marginRight: 6 }}
+                  />
+                  <Text
+                    className="font-bold text-[14px]"
+                    style={{ color: tintColor }}
+                  >
+                    查看全部 {item.commentCount} 条评论
+                  </Text>
+                </BouncyButton>
+              </View>
+            )}
         </Animated.View>
 
         {/* 5. 游客提示卡片 */}
@@ -323,7 +344,7 @@ export default function GuestDetailScreen() {
 
           {/* 登录按钮 */}
           <BouncyButton
-            onPress={() => router.push('/login' as any)}
+            onPress={() => router.push('/login')}
             className="w-full h-12 rounded-full items-center justify-center mb-3.5"
             style={{ backgroundColor: tintColor }}
           >

--- a/app/login/index.tsx
+++ b/app/login/index.tsx
@@ -1,7 +1,6 @@
 import CookieManager from '@react-native-cookies/cookies';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
-import * as SecureStore from 'expo-secure-store';
 import { useRef, useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { WebView } from 'react-native-webview';
@@ -11,6 +10,7 @@ import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useVerificationStore } from '@/store/useVerificationStore';
+import { syncNativeSessionCookies } from '@/utils/authSession';
 
 export default function LoginScreen() {
   const colorScheme = useColorScheme();
@@ -65,16 +65,11 @@ export default function LoginScreen() {
           .map(([name, value]) => `${name}=${value}`)
           .join('; ');
 
-        // 尝试保存到 SecureStore 作为备份，但 Android 有 2048 字节限制，超出会崩溃
+        // 同步原生 Cookie 与兼容备份；超长 Cookie 会主动清除旧备份。
         try {
-          if (cookieString.length < 2000) {
-            await SecureStore.setItemAsync('user_cookies', cookieString);
-          }
-        } catch (e) {
-          console.warn(
-            '⚠️ 无法保存 Cookie 到 SecureStore (可能超出长度限制):',
-            e,
-          );
+          await syncNativeSessionCookies(cookieString);
+        } catch {
+          console.warn('⚠️ 无法同步原生登录会话');
         }
 
         useAuthStore.getState().setCookies(cookieString);
@@ -85,13 +80,13 @@ export default function LoginScreen() {
           if (me) {
             useAuthStore.getState().addAccount(cookieString, me);
           }
-        } catch (e) {
-          console.error('⚠️ 预抓取用户信息失败 (不影响登录):', e);
+        } catch {
+          console.error('⚠️ 预抓取用户信息失败（不影响登录）');
         }
 
         useVerificationStore.getState().hide(); // 登录成功后强制关闭验证弹窗
         queryClient.clear(); // 清理缓存，强制重新拉取数据 (解决 feed 不更新问题)
-        console.log('✅ 登录 Cookie 已保存至 SecureStore 和 AuthStore');
+        console.log('✅ 登录会话已保存');
 
         // 成功后跳转，确保存储生效
         if (router.canGoBack()) {
@@ -101,13 +96,13 @@ export default function LoginScreen() {
           router.replace({
             pathname: '/(tabs)',
             params: { tab: 'profile' },
-          } as any);
+          });
         }
       } else if (hasZc0 && !hasZseCk) {
         console.log('⚠️ 捕获到 z_c0 但缺失 __zse_ck，请在验证页面稍候...');
       }
-    } catch (error) {
-      console.error('❌ 获取 Cookie 失败:', error);
+    } catch {
+      console.error('❌ 获取 Cookie 失败');
     }
   };
 

--- a/app/user/[id]/followers.tsx
+++ b/app/user/[id]/followers.tsx
@@ -1,15 +1,19 @@
 import { FlashList } from '@shopify/flash-list';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
+import { Stack, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator } from 'react-native';
+import type { ZhihuMemberListItem } from '@/api/zhihu';
 import { getMemberFollowers } from '@/api/zhihu';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { UserCard } from '@/components/UserCard';
+import { refreshInfiniteQuery } from '@/utils/query';
+import { getNextPageOffset } from '@/utils/userProfile';
 
 export default function FollowersScreen() {
-  const { id } = useLocalSearchParams();
-  const _router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
   const primaryColor = useThemeColor({}, 'primary');
+  const queryClient = useQueryClient();
 
   const {
     data,
@@ -17,18 +21,16 @@ export default function FollowersScreen() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isError,
     refetch,
     isRefetching,
   } = useInfiniteQuery({
     queryKey: ['user-followers', id],
-    queryFn: ({ pageParam = 0 }) =>
-      getMemberFollowers(id as string, 20, pageParam as number),
+    queryFn: ({ pageParam = 0 }) => getMemberFollowers(id, 20, pageParam),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const nextUrl = lastPage.paging?.next;
-      const match = nextUrl?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
   });
 
@@ -37,17 +39,36 @@ export default function FollowersScreen() {
   return (
     <View className="flex-1">
       <Stack.Screen options={{ title: '关注者列表' }} />
-      <FlashList
+      <FlashList<ZhihuMemberListItem>
         data={users}
-        renderItem={({ item }) => <UserCard user={item} />}
-        {...({ estimatedItemSize: 80 } as any)}
-        onEndReached={() => hasNextPage && fetchNextPage()}
-        onRefresh={refetch}
+        keyExtractor={(item) => String(item.id || item.url_token)}
+        renderItem={({ item }) => (
+          <UserCard
+            user={item}
+            invalidateQueryKeys={[['user-followers', id]]}
+          />
+        )}
+        onEndReached={() => {
+          if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
+        }}
+        onRefresh={() =>
+          void refreshInfiniteQuery(
+            queryClient,
+            ['user-followers', id],
+            refetch,
+          )
+        }
         refreshing={isRefetching}
         ListEmptyComponent={() => (
           <View className="p-[50px] items-center">
             {isLoading ? (
               <ActivityIndicator color={primaryColor} />
+            ) : isError ? (
+              <QueryErrorView
+                compact
+                message="关注者加载失败"
+                onRetry={() => void refetch()}
+              />
             ) : (
               <Text type="secondary">还没有关注者喵</Text>
             )}

--- a/app/user/[id]/following.tsx
+++ b/app/user/[id]/following.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { FlashList } from '@shopify/flash-list';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useRef, useState } from 'react';
 import {
@@ -16,11 +16,19 @@ import {
   getMemberFollowingFavlists,
   getMemberFollowingQuestions,
   getMemberFollowingTopics,
+  type ZhihuFollowingColumnItem,
+  type ZhihuFollowingFavlistItem,
+  type ZhihuFollowingQuestionItem,
+  type ZhihuFollowingTopicContributionItem,
+  type ZhihuMemberListItem,
 } from '@/api/zhihu';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { UserCard } from '@/components/UserCard';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
+import { refreshInfiniteQuery } from '@/utils/query';
+import { getNextPageOffset } from '@/utils/userProfile';
 
 const TABS = [
   { key: 'users', title: '关注的人' },
@@ -28,12 +36,39 @@ const TABS = [
   { key: 'topics', title: '话题' },
   { key: 'questions', title: '问题' },
   { key: 'favlists', title: '收藏夹' },
-];
+] as const;
+
+type FollowingTabKey = (typeof TABS)[number]['key'];
+type FollowingListItem =
+  | ZhihuMemberListItem
+  | ZhihuFollowingColumnItem
+  | ZhihuFollowingTopicContributionItem
+  | ZhihuFollowingQuestionItem
+  | ZhihuFollowingFavlistItem;
+
+function getFollowingItemKey(item: FollowingListItem, tabKey: FollowingTabKey) {
+  if (tabKey === 'topics') {
+    return String((item as ZhihuFollowingTopicContributionItem).topic.id);
+  }
+  if (tabKey === 'users') {
+    const member = item as ZhihuMemberListItem;
+    return String(member.id || member.url_token);
+  }
+  return String(
+    (
+      item as
+        | ZhihuFollowingColumnItem
+        | ZhihuFollowingQuestionItem
+        | ZhihuFollowingFavlistItem
+    ).id,
+  );
+}
 
 export default function FollowingScreen() {
-  const { id } = useLocalSearchParams();
+  const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
-  const [activeTab, setActiveTab] = useState('users');
+  const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState<FollowingTabKey>('users');
   const [_currentPage, setCurrentPage] = useState(0);
   const [visitedTabs, setVisitedTabs] = useState<Record<string, boolean>>({
     users: true,
@@ -48,14 +83,11 @@ export default function FollowingScreen() {
   // 1. 关注的人 Query
   const usersQuery = useInfiniteQuery({
     queryKey: ['user-following-users', id],
-    queryFn: ({ pageParam = 0 }) =>
-      getMemberFollowing(id as string, 20, pageParam as number),
+    queryFn: ({ pageParam = 0 }) => getMemberFollowing(id, 20, pageParam),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const nextUrl = lastPage.paging?.next;
-      const match = nextUrl?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
     enabled: visitedTabs.users || activeTab === 'users',
   });
@@ -64,13 +96,11 @@ export default function FollowingScreen() {
   const columnsQuery = useInfiniteQuery({
     queryKey: ['user-following-columns', id],
     queryFn: ({ pageParam = 0 }) =>
-      getMemberFollowingColumns(id as string, pageParam as number, 20),
+      getMemberFollowingColumns(id, pageParam, 20),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const nextUrl = lastPage.paging?.next;
-      const match = nextUrl?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
     enabled: visitedTabs.columns || activeTab === 'columns',
   });
@@ -78,14 +108,11 @@ export default function FollowingScreen() {
   // 3. 关注的话题 Query
   const topicsQuery = useInfiniteQuery({
     queryKey: ['user-following-topics', id],
-    queryFn: ({ pageParam = 0 }) =>
-      getMemberFollowingTopics(id as string, pageParam as number, 20),
+    queryFn: ({ pageParam = 0 }) => getMemberFollowingTopics(id, pageParam, 20),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const nextUrl = lastPage.paging?.next;
-      const match = nextUrl?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
     enabled: visitedTabs.topics || activeTab === 'topics',
   });
@@ -94,13 +121,11 @@ export default function FollowingScreen() {
   const questionsQuery = useInfiniteQuery({
     queryKey: ['user-following-questions', id],
     queryFn: ({ pageParam = 0 }) =>
-      getMemberFollowingQuestions(id as string, pageParam as number, 20),
+      getMemberFollowingQuestions(id, pageParam, 20),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const nextUrl = lastPage.paging?.next;
-      const match = nextUrl?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
     enabled: visitedTabs.questions || activeTab === 'questions',
   });
@@ -109,23 +134,23 @@ export default function FollowingScreen() {
   const favlistsQuery = useInfiniteQuery({
     queryKey: ['user-following-favlists', id],
     queryFn: ({ pageParam = 0 }) =>
-      getMemberFollowingFavlists(id as string, pageParam as number, 20),
+      getMemberFollowingFavlists(id, pageParam, 20),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const nextUrl = lastPage.paging?.next;
-      const match = nextUrl?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
     enabled: visitedTabs.favlists || activeTab === 'favlists',
   });
 
-  const getQueryState = (tabKey: string) => {
+  const getQueryState = (tabKey: FollowingTabKey) => {
     switch (tabKey) {
       case 'users':
         return {
+          queryKey: ['user-following-users', id] as const,
           data: usersQuery.data?.pages.flatMap((page) => page.data) || [],
           isLoading: usersQuery.isLoading,
+          isError: usersQuery.isError,
           isFetchingNextPage: usersQuery.isFetchingNextPage,
           hasNextPage: usersQuery.hasNextPage,
           fetchNextPage: usersQuery.fetchNextPage,
@@ -134,8 +159,10 @@ export default function FollowingScreen() {
         };
       case 'columns':
         return {
+          queryKey: ['user-following-columns', id] as const,
           data: columnsQuery.data?.pages.flatMap((page) => page.data) || [],
           isLoading: columnsQuery.isLoading,
+          isError: columnsQuery.isError,
           isFetchingNextPage: columnsQuery.isFetchingNextPage,
           hasNextPage: columnsQuery.hasNextPage,
           fetchNextPage: columnsQuery.fetchNextPage,
@@ -144,8 +171,10 @@ export default function FollowingScreen() {
         };
       case 'topics':
         return {
+          queryKey: ['user-following-topics', id] as const,
           data: topicsQuery.data?.pages.flatMap((page) => page.data) || [],
           isLoading: topicsQuery.isLoading,
+          isError: topicsQuery.isError,
           isFetchingNextPage: topicsQuery.isFetchingNextPage,
           hasNextPage: topicsQuery.hasNextPage,
           fetchNextPage: topicsQuery.fetchNextPage,
@@ -154,8 +183,10 @@ export default function FollowingScreen() {
         };
       case 'questions':
         return {
+          queryKey: ['user-following-questions', id] as const,
           data: questionsQuery.data?.pages.flatMap((page) => page.data) || [],
           isLoading: questionsQuery.isLoading,
+          isError: questionsQuery.isError,
           isFetchingNextPage: questionsQuery.isFetchingNextPage,
           hasNextPage: questionsQuery.hasNextPage,
           fetchNextPage: questionsQuery.fetchNextPage,
@@ -164,8 +195,10 @@ export default function FollowingScreen() {
         };
       case 'favlists':
         return {
+          queryKey: ['user-following-favlists', id] as const,
           data: favlistsQuery.data?.pages.flatMap((page) => page.data) || [],
           isLoading: favlistsQuery.isLoading,
+          isError: favlistsQuery.isError,
           isFetchingNextPage: favlistsQuery.isFetchingNextPage,
           hasNextPage: favlistsQuery.hasNextPage,
           fetchNextPage: favlistsQuery.fetchNextPage,
@@ -174,8 +207,10 @@ export default function FollowingScreen() {
         };
       default:
         return {
+          queryKey: ['user-following-unknown', id] as const,
           data: [],
           isLoading: false,
+          isError: false,
           isFetchingNextPage: false,
           hasNextPage: false,
           fetchNextPage: () => {},
@@ -193,38 +228,51 @@ export default function FollowingScreen() {
     setVisitedTabs((prev) => ({ ...prev, [tabKey]: true }));
   };
 
-  const renderItem = ({ item, tabKey }: { item: any; tabKey: string }) => {
+  const renderItem = ({
+    item,
+    tabKey,
+  }: {
+    item: FollowingListItem;
+    tabKey: FollowingTabKey;
+  }) => {
     if (tabKey === 'users') {
-      return <UserCard user={item} />;
+      const member = item as ZhihuMemberListItem;
+      return (
+        <UserCard
+          user={member}
+          invalidateQueryKeys={[['user-following-users', id]]}
+        />
+      );
     }
     if (tabKey === 'columns') {
+      const column = item as ZhihuFollowingColumnItem;
       return (
         <Pressable
           className="flex-row items-center p-4"
           style={{ borderBottomWidth: 0.5, borderBottomColor: borderColor }}
-          onPress={() => router.push(`/column/${item.id}`)}
+          onPress={() => router.push(`/column/${column.id}`)}
         >
           <Image
-            source={{ uri: item.image_url }}
+            source={{ uri: column.image_url }}
             className="w-12 h-12 rounded-lg"
           />
           <View className="flex-1 ml-3 bg-transparent">
             <Text className="text-base font-semibold" numberOfLines={1}>
-              {item.title}
+              {column.title}
             </Text>
             <Text
               type="secondary"
               className="text-[13px] mt-0.5"
               numberOfLines={1}
             >
-              {item.intro || item.excerpt || '这个专栏没有简介喵'}
+              {column.intro || column.excerpt || '这个专栏没有简介喵'}
             </Text>
             <View className="flex-row mt-1 bg-transparent">
               <Text type="secondary" className="text-xs">
-                {item.followers || 0} 关注者
+                {column.followers || 0} 关注者
               </Text>
               <Text type="secondary" className="text-xs ml-3">
-                {item.articles_count || 0} 文章
+                {column.articles_count || 0} 文章
               </Text>
             </View>
           </View>
@@ -232,7 +280,7 @@ export default function FollowingScreen() {
       );
     }
     if (tabKey === 'topics') {
-      const topic = item.topic;
+      const topic = (item as ZhihuFollowingTopicContributionItem).topic;
       if (!topic) return null;
       return (
         <Pressable
@@ -268,25 +316,26 @@ export default function FollowingScreen() {
       );
     }
     if (tabKey === 'questions') {
+      const question = item as ZhihuFollowingQuestionItem;
       return (
         <Pressable
           className="p-4"
           style={{ borderBottomWidth: 0.5, borderBottomColor: borderColor }}
-          onPress={() => router.push(`/question/${item.id}`)}
+          onPress={() => router.push(`/question/${question.id}`)}
         >
           <Text className="text-base font-semibold" numberOfLines={2}>
-            {item.title}
+            {question.title}
           </Text>
           <View className="flex-row mt-2 bg-transparent items-center">
             <Text type="secondary" className="text-xs">
-              {item.answer_count || 0} 个回答
+              {question.answer_count || 0} 个回答
             </Text>
             <Text type="secondary" className="text-xs ml-3">
-              {item.follower_count || 0} 人关注
+              {question.follower_count || 0} 人关注
             </Text>
-            {item.author?.name && (
+            {question.author?.name && (
               <Text type="secondary" className="text-xs ml-auto">
-                提问者: {item.author.name}
+                提问者: {question.author.name}
               </Text>
             )}
           </View>
@@ -294,39 +343,41 @@ export default function FollowingScreen() {
       );
     }
     if (tabKey === 'favlists') {
+      const favlist = item as ZhihuFollowingFavlistItem;
       return (
         <Pressable
           className="flex-row items-center p-4"
           style={{ borderBottomWidth: 0.5, borderBottomColor: borderColor }}
-          onPress={() => router.push(`/collections/${item.id}`)}
+          onPress={() => router.push(`/collections/${favlist.id}`)}
         >
           <View
             className="w-12 h-12 rounded-lg justify-center items-center relative"
             style={{ backgroundColor: 'rgba(0,132,255,0.05)' }}
           >
             <Ionicons
-              name={item.is_public ? 'folder' : 'folder-outline'}
+              name={favlist.is_public ? 'folder' : 'folder-outline'}
               size={24}
               color={tint}
             />
           </View>
           <View className="flex-1 ml-3 bg-transparent">
             <Text className="text-base font-semibold" numberOfLines={1}>
-              {item.title}
+              {favlist.title}
             </Text>
             <Text
               type="secondary"
               className="text-[13px] mt-0.5"
               numberOfLines={1}
             >
-              {item.description || `创建者: ${item.creator?.name || '匿名'}`}
+              {favlist.description ||
+                `创建者: ${favlist.creator?.name || '匿名'}`}
             </Text>
             <View className="flex-row mt-1 bg-transparent">
               <Text type="secondary" className="text-xs">
-                {item.answer_count || 0} 内容
+                {favlist.answer_count || 0} 内容
               </Text>
               <Text type="secondary" className="text-xs ml-3">
-                {item.follower_count || 0} 关注者
+                {favlist.follower_count || 0} 关注者
               </Text>
             </View>
           </View>
@@ -338,7 +389,7 @@ export default function FollowingScreen() {
 
   return (
     <View className="flex-1">
-      <Stack.Screen options={{ title: '我的关注' }} />
+      <Stack.Screen options={{ title: '关注' }} />
 
       {/* Tab bar */}
       <View
@@ -386,17 +437,33 @@ export default function FollowingScreen() {
           const query = getQueryState(tab.key);
           return (
             <NativeView key={tab.key} className="flex-1">
-              <FlashList
+              <FlashList<FollowingListItem>
                 data={query.data}
+                keyExtractor={(item) => getFollowingItemKey(item, tab.key)}
                 renderItem={({ item }) => renderItem({ item, tabKey: tab.key })}
-                {...({ estimatedItemSize: 80 } as any)}
-                onEndReached={() => query.hasNextPage && query.fetchNextPage()}
-                onRefresh={query.refetch}
+                onEndReached={() => {
+                  if (query.hasNextPage && !query.isFetchingNextPage) {
+                    void query.fetchNextPage();
+                  }
+                }}
+                onRefresh={() =>
+                  void refreshInfiniteQuery(
+                    queryClient,
+                    query.queryKey,
+                    query.refetch,
+                  )
+                }
                 refreshing={query.isRefetching}
                 ListEmptyComponent={() => (
                   <View className="p-[50px] items-center">
                     {query.isLoading ? (
                       <ActivityIndicator color={tint} />
+                    ) : query.isError ? (
+                      <QueryErrorView
+                        compact
+                        message={`${tab.title}加载失败`}
+                        onRetry={() => void query.refetch()}
+                      />
                     ) : (
                       <Text type="secondary">这里空空如也喵</Text>
                     )}

--- a/app/user/[id]/index.tsx
+++ b/app/user/[id]/index.tsx
@@ -1,6 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
-import { FlashList } from '@shopify/flash-list';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { FlashList, type FlashListRef } from '@shopify/flash-list';
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
 import React, { useEffect, useRef, useState } from 'react';
 import {
@@ -20,22 +24,108 @@ import Reanimated, {
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
+  type FeedItem,
   followMember,
   getMe,
-  getMember,
   getMemberActivities,
   getMemberRelations,
+  getMemberWithFallback,
   searchContent,
   unfollowMember,
+  type ZhihuMember,
 } from '@/api/zhihu';
 import { addReadHistory } from '@/api/zhihu/history';
 import { FeedCard } from '@/components/FeedCard';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
+import { useAuthStore } from '@/store/useAuthStore';
 import { useSettingsStore } from '@/store/useSettingsStore';
+import type { ZhihuAuthor, ZhihuSearchResultItem } from '@/types/zhihu';
+import { refreshInfiniteQuery } from '@/utils/query';
+import {
+  getNextPageOffset,
+  isOwnMemberProfile,
+  normalizeUserFeedType,
+  type UserFeedType,
+} from '@/utils/userProfile';
 
-const AnimatedFlashList = Reanimated.createAnimatedComponent(FlashList) as any;
+const AnimatedFlashList = Reanimated.createAnimatedComponent(FlashList);
+
+interface ProfileContentSegment {
+  type?: string;
+  content?: string;
+  url?: string;
+}
+
+interface ProfileContentItem {
+  id?: string | number;
+  url?: string;
+  type?: string;
+  title?: string;
+  excerpt?: string;
+  content?: string | ProfileContentSegment[];
+  image_url?: string;
+  thumbnail?: string;
+  voteup_count?: number;
+  reaction_count?: number;
+  like_count?: number;
+  comment_count?: number;
+  favlists_count?: number;
+  favorite_count?: number;
+  answer_count?: number;
+  follower_count?: number;
+  author?: Partial<ZhihuAuthor>;
+  question?: {
+    id?: string | number;
+    title?: string;
+    name?: string;
+  };
+  relationship?: {
+    voting?: number;
+  };
+  reaction?: {
+    statistics?: {
+      comments?: number;
+      favorites?: number;
+    };
+  };
+  thumbnail_info?: {
+    thumbnails?: Array<{ url?: string }>;
+  };
+}
+
+interface ProfileActivityItem {
+  id?: string | number;
+  url?: string;
+  target?: ProfileContentItem;
+}
+
+function getProfileContentItem(
+  item: unknown,
+  tabKey: ProfileTabKey,
+): ProfileContentItem | null {
+  if (!item || typeof item !== 'object') return null;
+  const activityItem = item as ProfileActivityItem;
+  const displayItem =
+    tabKey === 'activities'
+      ? activityItem.target || activityItem
+      : activityItem;
+  if (!displayItem.id && !displayItem.url) return null;
+  return displayItem;
+}
+
+function getProfileListItemKey(item: unknown) {
+  if (!item || typeof item !== 'object') return 'invalid-profile-item';
+  const profileItem = item as ProfileActivityItem;
+  return String(
+    profileItem.id ||
+      profileItem.target?.id ||
+      profileItem.url ||
+      profileItem.target?.url,
+  );
+}
 
 const PROFILE_TABS = [
   { key: 'activities', label: '动态', countKey: undefined },
@@ -47,16 +137,35 @@ const PROFILE_TABS = [
 
 type ProfileTabKey = (typeof PROFILE_TABS)[number]['key'];
 
+function getInitialProfileTab(tab: string | undefined): ProfileTabKey {
+  return PROFILE_TABS.some((profileTab) => profileTab.key === tab)
+    ? (tab as ProfileTabKey)
+    : 'answers';
+}
+
 export default function UserDetailScreen() {
   const colorScheme = useColorScheme();
   const _insets = useSafeAreaInsets();
-  const { id, avatar: initialAvatar } = useLocalSearchParams();
+  const {
+    id,
+    avatar: initialAvatar,
+    tab: initialTabParam,
+  } = useLocalSearchParams<{
+    id: string;
+    avatar?: string;
+    tab?: string;
+  }>();
   const router = useRouter();
   const navigation = useNavigation();
+  const queryClient = useQueryClient();
+  const initialTab = getInitialProfileTab(initialTabParam);
+  const initialTabIndex = PROFILE_TABS.findIndex(
+    (profileTab) => profileTab.key === initialTab,
+  );
 
-  const [activeTab, setActiveTab] = useState<ProfileTabKey>('answers');
+  const [activeTab, setActiveTab] = useState<ProfileTabKey>(initialTab);
   const [visitedTabs, setVisitedTabs] = useState<Record<string, boolean>>({
-    answers: true,
+    [initialTab]: true,
   });
   const [sortBy, setSortBy] = useState<'created' | 'voteups'>('created');
   const [followLoading, setFollowLoading] = useState(false);
@@ -78,12 +187,18 @@ export default function UserDetailScreen() {
   const scrollYPins = useSharedValue(0);
 
   // 2. 列表引用，用于程序控制滚动以对齐 Header 高度
-  const listRefs = useRef<(any | null)[]>([null, null, null, null, null]);
+  const listRefs = useRef<Array<FlashListRef<unknown> | null>>([
+    null,
+    null,
+    null,
+    null,
+    null,
+  ]);
 
   // 3. 当前活跃的 Tab 索引与 PagerView 滑动状态
-  const activeIndex = useSharedValue(1); // 默认是 'answers' (index 1)
-  const activeIndexRef = useRef(1);
-  const pagerPosition = useSharedValue(1);
+  const activeIndex = useSharedValue(initialTabIndex);
+  const activeIndexRef = useRef(initialTabIndex);
+  const pagerPosition = useSharedValue(initialTabIndex);
   const pagerOffset = useSharedValue(0);
 
   // 获取对应 Tab 索引的 shared value
@@ -159,7 +274,7 @@ export default function UserDetailScreen() {
       currentScrollY,
       [0, maxScroll.value],
       [0, -maxScroll.value],
-      'clamp' as any,
+      'clamp',
     );
 
     return {
@@ -222,53 +337,50 @@ export default function UserDetailScreen() {
   const { primaryColor: customPrimaryColor } = useSettingsStore();
   const primaryColor = customPrimaryColor || '#0084ff';
 
-  const { data: me } = useQuery({ queryKey: ['me'], queryFn: () => getMe() });
-  const isMe = me?.id === id;
-
-  const { data: user, refetch: refetchUser } = useQuery({
-    queryKey: ['user-detail', id],
-    queryFn: async () => {
-      try {
-        return await getMember(id as string);
-      } catch (err: any) {
-        if (err.response?.status === 403)
-          return await getMember(
-            id as string,
-            'follower_count,headline,cover_url,description,answer_count,articles_count,question_count,pins_count',
-          );
-        return null;
-      }
-    },
+  const { cookies, me: storedMe } = useAuthStore();
+  const { data: fetchedMe } = useQuery({
+    queryKey: ['me'],
+    queryFn: () => getMe(),
+    enabled: !!cookies,
   });
+  const me = fetchedMe || storedMe;
+
+  const {
+    data: user,
+    isLoading: isUserLoading,
+    isError: isUserError,
+    refetch: refetchUser,
+  } = useQuery({
+    queryKey: ['user-detail', id],
+    queryFn: () => getMemberWithFallback(id),
+    enabled: !!id,
+  });
+  const isMe = isOwnMemberProfile(id, me, user);
 
   const enableBrowseHistory = useSettingsStore((s) => s.enableBrowseHistory);
 
   useEffect(() => {
-    if (enableBrowseHistory && user?.id) {
-      addReadHistory({
+    if (cookies && enableBrowseHistory && user?.id) {
+      void addReadHistory({
         content_token: String(user.id),
         content_type: 'profile',
+      }).catch(() => {
+        console.warn('记录用户主页浏览历史失败');
       });
     }
-  }, [enableBrowseHistory, user?.id]);
+  }, [cookies, enableBrowseHistory, user?.id]);
 
   // 1. 动态 Query
   const activitiesQuery = useInfiniteQuery({
     queryKey: ['user-activities', id],
-    queryFn: async ({ pageParam = 0 }) => {
+    queryFn: ({ pageParam = 0 }) => {
       const targetId = (user?.url_token || id) as string;
-      try {
-        return await getMemberActivities(targetId, 20, pageParam as number);
-      } catch (err) {
-        console.error('获取动态失败:', err);
-        return { data: [], paging: { is_end: true } };
-      }
+      return getMemberActivities(targetId, 20, pageParam);
     },
     initialPageParam: 0,
-    getNextPageParam: (lastPage: any) => {
+    getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const match = lastPage.paging?.next?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
     enabled: !!user && (visitedTabs.activities || activeTab === 'activities'),
   });
@@ -276,27 +388,21 @@ export default function UserDetailScreen() {
   // 2. 回答 Query
   const answersQuery = useInfiniteQuery({
     queryKey: ['user-answers', id, sortBy],
-    queryFn: async ({ pageParam = 0 }) => {
+    queryFn: ({ pageParam = 0 }) => {
       const targetId = (user?.url_token || id) as string;
       const include =
         'data[*].is_normal,admin_closed_comment,content,voteup_count,comment_count,favlists_count,created_time,updated_time,excerpt,reaction,relationship.voting,relationship.is_author,relationship.is_thanked;data[*].author;data[*].question.title';
-      try {
-        return await getMemberRelations(targetId, 'answers', {
-          limit: 20,
-          offset: pageParam as number,
-          include,
-          sort_by: sortBy,
-        });
-      } catch (err) {
-        console.error('获取回答失败:', err);
-        return { data: [], paging: { is_end: true } };
-      }
+      return getMemberRelations(targetId, 'answers', {
+        limit: 20,
+        offset: pageParam,
+        include,
+        sort_by: sortBy,
+      });
     },
     initialPageParam: 0,
-    getNextPageParam: (lastPage: any) => {
+    getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const match = lastPage.paging?.next?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
     enabled: !!user && (visitedTabs.answers || activeTab === 'answers'),
   });
@@ -304,26 +410,20 @@ export default function UserDetailScreen() {
   // 3. 提问 Query
   const questionsQuery = useInfiniteQuery({
     queryKey: ['user-questions', id],
-    queryFn: async ({ pageParam = 0 }) => {
+    queryFn: ({ pageParam = 0 }) => {
       const targetId = (user?.url_token || id) as string;
       const include =
         'data[*].created,answer_count,follower_count,admin_closed_comment,title,reaction,relationship.is_following;data[*].author';
-      try {
-        return await getMemberRelations(targetId, 'questions', {
-          limit: 20,
-          offset: pageParam as number,
-          include,
-        });
-      } catch (err) {
-        console.error('获取提问失败:', err);
-        return { data: [], paging: { is_end: true } };
-      }
+      return getMemberRelations(targetId, 'questions', {
+        limit: 20,
+        offset: pageParam,
+        include,
+      });
     },
     initialPageParam: 0,
-    getNextPageParam: (lastPage: any) => {
+    getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const match = lastPage.paging?.next?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
     enabled: !!user && (visitedTabs.questions || activeTab === 'questions'),
   });
@@ -331,26 +431,20 @@ export default function UserDetailScreen() {
   // 4. 文章 Query
   const articlesQuery = useInfiniteQuery({
     queryKey: ['user-articles', id],
-    queryFn: async ({ pageParam = 0 }) => {
+    queryFn: ({ pageParam = 0 }) => {
       const targetId = (user?.url_token || id) as string;
       const include =
         'data[*].comment_count,content,voteup_count,favlists_count,created,updated,title,excerpt,reaction,relationship.voting;data[*].author';
-      try {
-        return await getMemberRelations(targetId, 'articles', {
-          limit: 20,
-          offset: pageParam as number,
-          include,
-        });
-      } catch (err) {
-        console.error('获取文章失败:', err);
-        return { data: [], paging: { is_end: true } };
-      }
+      return getMemberRelations(targetId, 'articles', {
+        limit: 20,
+        offset: pageParam,
+        include,
+      });
     },
     initialPageParam: 0,
-    getNextPageParam: (lastPage: any) => {
+    getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const match = lastPage.paging?.next?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
     enabled: !!user && (visitedTabs.articles || activeTab === 'articles'),
   });
@@ -358,26 +452,20 @@ export default function UserDetailScreen() {
   // 5. 想法 Query
   const pinsQuery = useInfiniteQuery({
     queryKey: ['user-pins', id],
-    queryFn: async ({ pageParam = 0 }) => {
+    queryFn: ({ pageParam = 0 }) => {
       const targetId = (user?.url_token || id) as string;
       const include =
         'data[*].content,reaction_count,comment_count,created,reaction,relationship.voting;data[*].author';
-      try {
-        return await getMemberRelations(targetId, 'pins', {
-          limit: 20,
-          offset: pageParam as number,
-          include,
-        });
-      } catch (err) {
-        console.error('获取想法失败:', err);
-        return { data: [], paging: { is_end: true } };
-      }
+      return getMemberRelations(targetId, 'pins', {
+        limit: 20,
+        offset: pageParam,
+        include,
+      });
     },
     initialPageParam: 0,
-    getNextPageParam: (lastPage: any) => {
+    getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const match = lastPage.paging?.next?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
     enabled: !!user && (visitedTabs.pins || activeTab === 'pins'),
   });
@@ -386,10 +474,12 @@ export default function UserDetailScreen() {
     switch (tabKey) {
       case 'activities':
         return {
+          queryKey: ['user-activities', id] as const,
           data:
             activitiesQuery.data?.pages.flatMap((page) => page.data || []) ||
             [],
           isLoading: activitiesQuery.isLoading,
+          isError: activitiesQuery.isError,
           isFetchingNextPage: activitiesQuery.isFetchingNextPage,
           hasNextPage: activitiesQuery.hasNextPage,
           fetchNextPage: activitiesQuery.fetchNextPage,
@@ -398,9 +488,11 @@ export default function UserDetailScreen() {
         };
       case 'answers':
         return {
+          queryKey: ['user-answers', id, sortBy] as const,
           data:
             answersQuery.data?.pages.flatMap((page) => page.data || []) || [],
           isLoading: answersQuery.isLoading,
+          isError: answersQuery.isError,
           isFetchingNextPage: answersQuery.isFetchingNextPage,
           hasNextPage: answersQuery.hasNextPage,
           fetchNextPage: answersQuery.fetchNextPage,
@@ -409,9 +501,11 @@ export default function UserDetailScreen() {
         };
       case 'articles':
         return {
+          queryKey: ['user-articles', id] as const,
           data:
             articlesQuery.data?.pages.flatMap((page) => page.data || []) || [],
           isLoading: articlesQuery.isLoading,
+          isError: articlesQuery.isError,
           isFetchingNextPage: articlesQuery.isFetchingNextPage,
           hasNextPage: articlesQuery.hasNextPage,
           fetchNextPage: articlesQuery.fetchNextPage,
@@ -420,9 +514,11 @@ export default function UserDetailScreen() {
         };
       case 'questions':
         return {
+          queryKey: ['user-questions', id] as const,
           data:
             questionsQuery.data?.pages.flatMap((page) => page.data || []) || [],
           isLoading: questionsQuery.isLoading,
+          isError: questionsQuery.isError,
           isFetchingNextPage: questionsQuery.isFetchingNextPage,
           hasNextPage: questionsQuery.hasNextPage,
           fetchNextPage: questionsQuery.fetchNextPage,
@@ -431,8 +527,10 @@ export default function UserDetailScreen() {
         };
       case 'pins':
         return {
+          queryKey: ['user-pins', id] as const,
           data: pinsQuery.data?.pages.flatMap((page) => page.data || []) || [],
           isLoading: pinsQuery.isLoading,
+          isError: pinsQuery.isError,
           isFetchingNextPage: pinsQuery.isFetchingNextPage,
           hasNextPage: pinsQuery.hasNextPage,
           fetchNextPage: pinsQuery.fetchNextPage,
@@ -448,10 +546,13 @@ export default function UserDetailScreen() {
     hasNextPage: hasNextSearchPage,
     isFetchingNextPage: isFetchingNextSearchPage,
     isLoading: searchLoading,
+    isError: isSearchError,
+    isRefetching: isRefetchingSearch,
+    refetch: refetchSearch,
   } = useInfiniteQuery({
     queryKey: ['user-creations-search', user?.id, debouncedSearchQuery],
     queryFn: ({ pageParam = 0 }) =>
-      searchContent(debouncedSearchQuery, pageParam as number, 20, 'general', {
+      searchContent(debouncedSearchQuery, pageParam, 20, 'general', {
         restricted_scene: 'member',
         restricted_field: 'member_hash_id',
         restricted_value: user?.id,
@@ -460,8 +561,7 @@ export default function UserDetailScreen() {
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (lastPage.paging?.is_end) return undefined;
-      const match = lastPage.paging?.next?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
   });
 
@@ -502,13 +602,15 @@ export default function UserDetailScreen() {
     );
   };
 
-  const parseSearchResult = (item: any) => {
-    const obj = item.object;
-    if (!obj) return null;
+  const parseSearchResult = (item: ZhihuSearchResultItem): FeedItem | null => {
+    const obj = item.object as ProfileContentItem;
+    if (!obj || obj.id === null || obj.id === undefined) return null;
+    const feedType = normalizeUserFeedType(obj.type);
+    if (!feedType) return null;
     const highlight = item.highlight || {};
     return {
-      id: obj.id,
-      type: `${obj.type}s`,
+      id: String(obj.id),
+      type: feedType,
       title: highlight.title
         ? HighlightText(highlight.title)
         : obj.question?.name || obj.title || '无标题',
@@ -520,33 +622,89 @@ export default function UserDetailScreen() {
       voteCount: obj.voteup_count || 0,
       commentCount: obj.comment_count || 0,
       author: {
-        id: obj.author?.id,
-        name: obj.author?.name || '匿名用户',
-        avatar: obj.author?.avatar_url,
-        url_token: obj.author?.url_token,
+        id: obj.author?.id || user?.id || '',
+        name: obj.author?.name || user?.name || '匿名用户',
+        avatar: obj.author?.avatar_url || user?.avatar_url || '',
+        url_token: obj.author?.url_token || user?.url_token,
       },
-      questionId: obj.question?.id || obj.id,
+      questionId:
+        obj.question?.id !== undefined
+          ? String(obj.question.id)
+          : obj.id !== undefined
+            ? String(obj.id)
+            : undefined,
       voted: obj.relationship?.voting || 0,
+      favlistsCount: obj.favlists_count || obj.favorite_count || 0,
     };
   };
 
   const isSearching = debouncedSearchQuery.length > 0;
   const currentListItems = isSearching
     ? searchResults?.pages.flatMap(
-        (page) => page.data?.map(parseSearchResult).filter(Boolean) || [],
+        (page) =>
+          page.data
+            ?.map(parseSearchResult)
+            .filter((item): item is FeedItem => item !== null) || [],
       ) || []
     : [];
 
+  const refreshSearch = React.useCallback(() => {
+    return refreshInfiniteQuery(
+      queryClient,
+      ['user-creations-search', user?.id, debouncedSearchQuery],
+      refetchSearch,
+    );
+  }, [debouncedSearchQuery, queryClient, refetchSearch, user?.id]);
+
   const handleFollow = async () => {
-    if (followLoading) return;
+    if (followLoading || !user) return;
+    if (!cookies) {
+      router.push('/login');
+      return;
+    }
     setFollowLoading(true);
     try {
       const targetId = (user?.url_token || id) as string;
-      if (user?.is_following) await unfollowMember(targetId);
-      else await followMember(targetId);
-      refetchUser();
-    } catch (err) {
-      console.error('关注操作失败:', err);
+      const nextIsFollowing = !user.is_following;
+      const response = user.is_following
+        ? await unfollowMember(targetId)
+        : await followMember(targetId);
+      queryClient.setQueryData<ZhihuMember>(
+        ['user-detail', id],
+        (currentMember) =>
+          currentMember
+            ? {
+                ...currentMember,
+                is_following: nextIsFollowing,
+                follower_count:
+                  response.follower_count ??
+                  Math.max(
+                    0,
+                    (currentMember.follower_count || 0) +
+                      (nextIsFollowing ? 1 : -1),
+                  ),
+              }
+            : currentMember,
+      );
+      void refetchUser();
+
+      const myIdentifiers = [me?.id, me?.url_token].filter(
+        (identifier): identifier is string => typeof identifier === 'string',
+      );
+      await Promise.all(
+        myIdentifiers.flatMap((identifier) => [
+          queryClient.invalidateQueries({
+            queryKey: ['me-detail', identifier],
+            exact: true,
+          }),
+          queryClient.invalidateQueries({
+            queryKey: ['user-following-users', identifier],
+            exact: true,
+          }),
+        ]),
+      );
+    } catch {
+      console.error('关注操作失败');
       Alert.alert('提示', '操作失败，请重试');
     } finally {
       setFollowLoading(false);
@@ -631,7 +789,7 @@ export default function UserDetailScreen() {
             onPress={() => router.push(`/user/${user?.url_token || id}/mutual`)}
           >
             <Text className="text-[13px]">
-              <Text className="font-bold">{user.mutual_followees_count}</Text>{' '}
+              <Text className="font-bold">{user?.mutual_followees_count}</Text>{' '}
               位共同关注
             </Text>
             <Image
@@ -705,7 +863,7 @@ export default function UserDetailScreen() {
           onChangeText={setSearchQuery}
           returnKeyType="search"
         />
-        {isSearching && searchQuery.length > 0 && (
+        {searchQuery.length > 0 && (
           <Pressable onPress={() => setSearchQuery('')} className="p-[5px]">
             <Ionicons
               name="close-circle"
@@ -721,7 +879,7 @@ export default function UserDetailScreen() {
   const renderTabsSelector = () => (
     <View className="flex-row bg-transparent my-1 border-b border-gray-100 dark:border-gray-800">
       {PROFILE_TABS.map((tab, idx) => {
-        const count = tab.countKey ? (user as any)?.[tab.countKey] : undefined;
+        const count = tab.countKey ? user?.[tab.countKey] : undefined;
         const countStr = count !== undefined && count > 0 ? ` ${count}` : '';
         const isActive = activeTab === tab.key;
         return (
@@ -759,13 +917,15 @@ export default function UserDetailScreen() {
         className="flex-row px-[15px] py-2.5 bg-transparent"
         style={{ borderBottomWidth: 0 }}
       >
-        {[
-          { key: 'created', label: '最新' },
-          { key: 'voteups', label: '赞同' },
-        ].map((item) => (
+        {(
+          [
+            { key: 'created', label: '最新' },
+            { key: 'voteups', label: '赞同' },
+          ] as const
+        ).map((item) => (
           <Pressable
             key={item.key}
-            onPress={() => setSortBy(item.key as any)}
+            onPress={() => setSortBy(item.key)}
             className="px-3 py-1 mr-2.5 rounded"
             style={[
               sortBy === item.key && {
@@ -786,25 +946,18 @@ export default function UserDetailScreen() {
     );
   };
 
-  const renderItemContent = (item: any, tabKey: ProfileTabKey) => {
-    let displayItem = item as any;
-    if (tabKey === 'activities') {
-      displayItem = item.target || item;
-    }
-    if (!displayItem || (!displayItem.id && !displayItem.url)) return null;
+  const renderItemContent = (item: unknown, tabKey: ProfileTabKey) => {
+    const displayItem = getProfileContentItem(item, tabKey);
+    if (!displayItem) return null;
 
     const rawType = displayItem.type;
-    let mappedType: 'answers' | 'articles' | 'questions' | 'pins' = 'answers';
-    if (rawType === 'article') mappedType = 'articles';
-    else if (rawType === 'question') mappedType = 'questions';
-    else if (rawType === 'pin') mappedType = 'pins';
-    else if (rawType === 'zvideo' || rawType === 'video')
-      mappedType = 'answers';
+    const mappedType: UserFeedType =
+      normalizeUserFeedType(rawType) || 'answers';
 
     const getExcerptText = () => {
       if (rawType === 'pin') {
         if (Array.isArray(displayItem.content)) {
-          return (displayItem.content as any[])
+          return displayItem.content
             .filter((c) => c.type === 'text')
             .map((c) => c.content)
             .join('')
@@ -817,7 +970,7 @@ export default function UserDetailScreen() {
             .substring(0, 150);
         }
       }
-      const raw = (displayItem as any).excerpt || displayItem.content || '';
+      const raw = displayItem.excerpt || displayItem.content || '';
       if (typeof raw === 'string')
         return raw.replace(/<[^>]+>/g, '').substring(0, 150);
       return '';
@@ -827,12 +980,12 @@ export default function UserDetailScreen() {
       displayItem.image_url ||
       displayItem.thumbnail ||
       (rawType === 'pin' && Array.isArray(displayItem.content)
-        ? displayItem.content.find((c: any) => c.type === 'image')?.url
+        ? displayItem.content.find((content) => content.type === 'image')?.url
         : null) ||
       null;
 
-    const feedItem: any = {
-      id: displayItem.id?.toString() || Math.random().toString(),
+    const feedItem: FeedItem = {
+      id: displayItem.id?.toString() || String(displayItem.url),
       title: displayItem.question?.title || displayItem.title || '',
       questionId:
         displayItem.question?.id?.toString() ||
@@ -874,22 +1027,20 @@ export default function UserDetailScreen() {
       className="flex-1"
       style={{ backgroundColor: Colors[colorScheme].background }}
     >
-      {isSearching ? (
-        <FlashList
+      {isUserLoading ? (
+        <View className="flex-1 items-center justify-center bg-transparent">
+          <ActivityIndicator color={primaryColor} />
+        </View>
+      ) : isUserError || !user ? (
+        <QueryErrorView
+          message="用户资料加载失败"
+          onRetry={() => void refetchUser()}
+        />
+      ) : isSearching ? (
+        <FlashList<FeedItem>
           data={currentListItems}
-          renderItem={({ item }: { item: any }) => {
-            const rawType = item.type;
-            let mappedType: 'answers' | 'articles' | 'questions' | 'pins' =
-              'answers';
-            if (rawType === 'articles') mappedType = 'articles';
-            else if (rawType === 'questions') mappedType = 'questions';
-            else if (rawType === 'pins') mappedType = 'pins';
-            return <FeedCard item={{ ...item, type: mappedType }} />;
-          }}
-          keyExtractor={(item: any, index: number) =>
-            `user-search-item-${item.id || ''}-${index}`
-          }
-          {...({ estimatedItemSize: 200 } as any)}
+          renderItem={({ item }) => <FeedCard item={item} />}
+          keyExtractor={(item) => `user-search-item-${item.id}`}
           scrollEventThrottle={16}
           ListHeaderComponent={
             <View className="bg-transparent">
@@ -911,13 +1062,25 @@ export default function UserDetailScreen() {
               ) : null}
             </View>
           }
+          ListEmptyComponent={
+            searchLoading ? null : isSearchError ? (
+              <QueryErrorView
+                message="搜索结果加载失败"
+                onRetry={() => void refreshSearch()}
+              />
+            ) : (
+              <View className="items-center py-20 bg-transparent">
+                <Text type="secondary">没有找到相关创作</Text>
+              </View>
+            )
+          }
           onEndReached={() => {
             if (hasNextSearchPage && !isFetchingNextSearchPage)
               fetchNextSearchPage();
           }}
           onEndReachedThreshold={0.5}
-          onRefresh={refetchUser}
-          refreshing={followLoading}
+          onRefresh={() => void refreshSearch()}
+          refreshing={isRefetchingSearch}
         />
       ) : (
         <View style={{ flex: 1 }}>
@@ -969,7 +1132,7 @@ export default function UserDetailScreen() {
           <PagerView
             ref={pagerRef}
             style={{ flex: 1 }}
-            initialPage={1} // 默认是 'answers'
+            initialPage={initialTabIndex}
             onPageScroll={(e) => {
               pagerPosition.value = e.nativeEvent.position;
               pagerOffset.value = e.nativeEvent.offset;
@@ -1010,17 +1173,16 @@ export default function UserDetailScreen() {
               return (
                 <NativeView key={tab.key} className="flex-1">
                   <AnimatedFlashList
-                    ref={(ref: any) => {
+                    ref={(ref: FlashListRef<unknown> | null) => {
                       listRefs.current[idx] = ref;
                     }}
                     data={query.data}
-                    renderItem={({ item }: any) =>
+                    renderItem={({ item }: { item: unknown }) =>
                       renderItemContent(item, tab.key)
                     }
-                    keyExtractor={(item: any, index: number) =>
-                      `user-item-${tab.key}-${item.id || ''}-${index}`
+                    keyExtractor={(item: unknown) =>
+                      `user-item-${tab.key}-${getProfileListItemKey(item)}`
                     }
-                    {...({ estimatedItemSize: 200 } as any)}
                     contentContainerStyle={{ paddingTop: headerHeight }}
                     scrollEventThrottle={16}
                     drawDistance={1000}
@@ -1056,13 +1218,31 @@ export default function UserDetailScreen() {
                         ) : null}
                       </View>
                     }
+                    ListEmptyComponent={
+                      query.isLoading ? null : query.isError ? (
+                        <QueryErrorView
+                          message={`${tab.label}加载失败`}
+                          onRetry={() => void query.refetch()}
+                        />
+                      ) : (
+                        <View className="items-center py-20 bg-transparent">
+                          <Text type="secondary">暂无{tab.label}内容</Text>
+                        </View>
+                      )
+                    }
                     onEndReached={() => {
                       if (query.hasNextPage && !query.isFetchingNextPage) {
                         query.fetchNextPage();
                       }
                     }}
                     onEndReachedThreshold={0.5}
-                    onRefresh={query.refetch}
+                    onRefresh={() =>
+                      void refreshInfiniteQuery(
+                        queryClient,
+                        query.queryKey,
+                        query.refetch,
+                      )
+                    }
                     refreshing={query.isRefetching}
                   />
                 </NativeView>

--- a/app/user/[id]/mutual.tsx
+++ b/app/user/[id]/mutual.tsx
@@ -1,15 +1,19 @@
 import { FlashList } from '@shopify/flash-list';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
+import { Stack, useLocalSearchParams } from 'expo-router';
 import { ActivityIndicator } from 'react-native';
+import type { ZhihuMemberListItem } from '@/api/zhihu';
 import { getMemberMutual } from '@/api/zhihu';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { UserCard } from '@/components/UserCard';
+import { refreshInfiniteQuery } from '@/utils/query';
+import { getNextPageOffset } from '@/utils/userProfile';
 
 export default function MutualFollowersScreen() {
-  const { id } = useLocalSearchParams();
-  const _router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
   const primaryColor = useThemeColor({}, 'primary');
+  const queryClient = useQueryClient();
 
   const {
     data,
@@ -17,18 +21,16 @@ export default function MutualFollowersScreen() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isError,
     refetch,
     isRefetching,
   } = useInfiniteQuery({
     queryKey: ['user-mutual', id],
-    queryFn: ({ pageParam = 0 }) =>
-      getMemberMutual(id as string, 20, pageParam as number),
+    queryFn: ({ pageParam = 0 }) => getMemberMutual(id, 20, pageParam),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const nextUrl = lastPage.paging?.next;
-      const match = nextUrl?.match(/offset=(\d+)/);
-      return match ? parseInt(match[1], 10) : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
   });
 
@@ -37,17 +39,29 @@ export default function MutualFollowersScreen() {
   return (
     <View className="flex-1">
       <Stack.Screen options={{ title: '共同关注' }} />
-      <FlashList
+      <FlashList<ZhihuMemberListItem>
         data={users}
-        renderItem={({ item }) => <UserCard user={item} />}
-        {...({ estimatedItemSize: 80 } as any)}
-        onEndReached={() => hasNextPage && fetchNextPage()}
-        onRefresh={refetch}
+        keyExtractor={(item) => String(item.id || item.url_token)}
+        renderItem={({ item }) => (
+          <UserCard user={item} invalidateQueryKeys={[['user-mutual', id]]} />
+        )}
+        onEndReached={() => {
+          if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
+        }}
+        onRefresh={() =>
+          void refreshInfiniteQuery(queryClient, ['user-mutual', id], refetch)
+        }
         refreshing={isRefetching}
         ListEmptyComponent={() => (
           <View className="p-[50px] items-center">
             {isLoading ? (
               <ActivityIndicator color={primaryColor} />
+            ) : isError ? (
+              <QueryErrorView
+                compact
+                message="共同关注加载失败"
+                onRetry={() => void refetch()}
+              />
             ) : (
               <Text type="secondary">没有共同关注喵</Text>
             )}

--- a/app/user/[id]/stream.tsx
+++ b/app/user/[id]/stream.tsx
@@ -1,5 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
-import { FlashList } from '@shopify/flash-list';
+import {
+  FlashList,
+  type FlashListRef,
+  type ListRenderItemInfo,
+  type ViewToken,
+} from '@shopify/flash-list';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { BlurView } from 'expo-blur';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -17,6 +22,8 @@ import {
   Animated,
   Image,
   LayoutAnimation,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   View as NativeView,
   Platform,
   Pressable,
@@ -26,20 +33,111 @@ import {
 import Reanimated from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
-  getMember,
   getMemberActivities,
   getMemberRelations,
+  getMemberWithFallback,
 } from '@/api/zhihu';
+import type { ZhihuMemberActivity } from '@/api/zhihu/member';
 import { BouncyButton } from '@/components/BouncyButton';
 import { LikeButton } from '@/components/LikeButton';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { ShareMenu } from '@/components/ShareMenu';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
 import { ZhihuContent } from '@/features/rich-content';
+import { useCollectionAction } from '@/hooks/useCollectionAction';
+import { useCollectionStore } from '@/store/useCollectionStore';
+import type { ZhihuMemberRelation } from '@/types/zhihu';
 import { formatDate } from '@/utils/date';
+import { getNextPageOffset } from '@/utils/userProfile';
 
-const StreamItem = forwardRef(
+type StreamTab = 'activities' | 'answers' | 'questions' | 'articles' | 'pins';
+type StreamItemType = 'answer' | 'article' | 'question' | 'pin' | 'video';
+type StreamApiItem = ZhihuMemberActivity | ZhihuMemberRelation;
+
+interface StreamContentSegment {
+  type?: string;
+  content?: string;
+  data_draft_title?: string;
+}
+
+interface StreamContentItem {
+  id: string | number;
+  type?: string;
+  url?: string;
+  title?: string;
+  content?: string | StreamContentSegment[];
+  excerpt?: string;
+  voteup_count?: number;
+  like_count?: number;
+  reaction_count?: number;
+  comment_count?: number;
+  favlists_count?: number;
+  favlistsCount?: number;
+  favorite_count?: number;
+  answer_count?: number;
+  follower_count?: number;
+  created?: number;
+  created_time?: number;
+  updated?: number;
+  updated_time?: number;
+  author?: { name?: string; headline?: string };
+  question?: { id?: string | number; title?: string };
+  relationship?: { voting?: number };
+  reaction?: {
+    statistics?: {
+      favorites?: number;
+      like_count?: number;
+    };
+  };
+}
+
+interface StreamItemHandle {
+  measureFooter: (
+    callback: (x: number, y: number, width: number, height: number) => void,
+  ) => void;
+  id: string;
+}
+
+interface StreamItemProps {
+  item: StreamContentItem;
+  type: StreamItemType;
+  isExpanded: boolean;
+  onToggle: (id: string, expanded: boolean) => void;
+  onShare: (item: StreamContentItem) => void;
+  isHighlighted: boolean;
+  isCollapsedHighlighted?: boolean;
+}
+
+function getDisplayItem(
+  item: StreamApiItem,
+  activeTab: StreamTab,
+): StreamContentItem | null {
+  const candidate =
+    activeTab === 'activities' && 'target' in item && item.target
+      ? item.target
+      : item;
+
+  if (!candidate || typeof candidate !== 'object' || !('id' in candidate)) {
+    return null;
+  }
+  if (candidate.id === null || candidate.id === undefined) return null;
+
+  return candidate as StreamContentItem;
+}
+
+function normalizeStreamTab(type: string | undefined): StreamTab {
+  return type === 'activities' ||
+    type === 'answers' ||
+    type === 'questions' ||
+    type === 'articles' ||
+    type === 'pins'
+    ? type
+    : 'answers';
+}
+
+const StreamItem = forwardRef<StreamItemHandle, StreamItemProps>(
   (
     {
       item,
@@ -48,32 +146,21 @@ const StreamItem = forwardRef(
       onToggle,
       onShare,
       isCollapsedHighlighted,
-    }: {
-      item: any;
-      type: 'answer' | 'article' | 'question' | 'pin' | 'video';
-      isExpanded: boolean;
-      onToggle: (id: string, expanded: boolean) => void;
-      onShare: (item: any) => void;
-      isHighlighted: boolean;
-      isCollapsedHighlighted?: boolean;
-    },
+    }: StreamItemProps,
     ref,
   ) => {
     const colorScheme = useColorScheme();
     const router = useRouter();
     const footerRef = useRef<NativeView>(null);
 
-    const { useCollectionStore } = require('@/store/useCollectionStore');
-    const { useCollectionAction } = require('@/hooks/useCollectionAction');
-
     const warningColor = useThemeColor({}, 'warning');
     const primaryColor = useThemeColor({}, 'primary');
     const isCollectable = type === 'answer' || type === 'article';
-    const storeCollected = useCollectionStore((state: any) =>
+    const storeCollected = useCollectionStore((state) =>
       item?.id ? state.collectedStatusMap[item.id.toString()] : false,
     );
     const isCollected = storeCollected !== undefined ? storeCollected : false;
-    const storeOffset = useCollectionStore((state: any) =>
+    const storeOffset = useCollectionStore((state) =>
       item?.id ? state.collectedCountOffsetMap[item.id.toString()] || 0 : 0,
     );
     const displayCount =
@@ -85,18 +172,18 @@ const StreamItem = forwardRef(
     const { toggleCollect } = useCollectionAction();
 
     useImperativeHandle(ref, () => ({
-      measureFooter: (cb: any) => footerRef.current?.measureInWindow(cb),
-      id: item?.id?.toString() || Math.random().toString(),
+      measureFooter: (callback) => footerRef.current?.measureInWindow(callback),
+      id: item.id.toString(),
     }));
 
     const getFullContent = () => {
       if (!item) return '';
       if (type === 'pin' && Array.isArray(item.content)) {
         return item.content
-          .map((c: any) => {
-            if (c.type === 'text') return c.content;
-            if (c.type === 'link_card')
-              return `[链接: ${c.data_draft_title || '查看详情'}]`;
+          .map((segment) => {
+            if (segment.type === 'text') return segment.content;
+            if (segment.type === 'link_card')
+              return `[链接: ${segment.data_draft_title || '查看详情'}]`;
             return '';
           })
           .join('\n')
@@ -115,8 +202,8 @@ const StreamItem = forwardRef(
       if (type === 'pin') {
         if (Array.isArray(item.content)) {
           return item.content
-            .filter((c: any) => c.type === 'text')
-            .map((c: any) => c.content)
+            .filter((segment) => segment.type === 'text')
+            .map((segment) => segment.content)
             .join('')
             .replace(/<[^>]+>/g, '')
             .substring(0, 100);
@@ -148,7 +235,7 @@ const StreamItem = forwardRef(
         router.push({
           pathname: '/video/[id]',
           params: { id: item.id, title: item.title },
-        } as any);
+        });
       } else {
         router.push({
           pathname: `/${type}/[id]`,
@@ -157,7 +244,7 @@ const StreamItem = forwardRef(
             title: item.title || item.question?.title,
             questionId: item.question?.id,
           },
-        } as any);
+        });
       }
     };
 
@@ -167,9 +254,8 @@ const StreamItem = forwardRef(
       (fullText.length > 120 ||
         (typeof item.content === 'string' &&
           (item.content.includes('<img') || item.content.includes('<figure'))));
-
-    const _displayTypeForShare =
-      type === 'answer' ? 'answer' : type === 'article' ? 'article' : 'pin';
+    const itemTimestamp =
+      item.updated_time ?? item.updated ?? item.created_time ?? item.created;
 
     return (
       <BouncyButton
@@ -356,7 +442,7 @@ const StreamItem = forwardRef(
               >
                 <Ionicons name="chatbubble-outline" size={16} color="#888" />
                 <Text className="text-[#888] ml-1 text-xs font-semibold">
-                  {item.comment_count > 0 ? item.comment_count : '评论'}
+                  {(item.comment_count ?? 0) > 0 ? item.comment_count : '评论'}
                 </Text>
               </Pressable>
               {isCollectable && (
@@ -396,17 +482,7 @@ const StreamItem = forwardRef(
               type="secondary"
               className="text-xs text-tertiary dark:text-tertiary-dark mr-3"
             >
-              {item.updated_time ||
-              item.updated ||
-              item.created_time ||
-              item.created
-                ? formatDate(
-                    item.updated_time ||
-                      item.updated ||
-                      item.created_time ||
-                      item.created,
-                  )
-                : ''}
+              {itemTimestamp ? formatDate(itemTimestamp) : ''}
             </Text>
             <BouncyButton
               onPress={() => onShare(item)}
@@ -431,54 +507,56 @@ export default function UserStreamScreen() {
   const colorScheme = useColorScheme();
   const primaryColor = useThemeColor({}, 'primary');
   const insets = useSafeAreaInsets();
-  const flashListRef = useRef<any>(null);
+  const flashListRef = useRef<FlashListRef<StreamApiItem>>(null);
   const [hasScrolledToInitial, setHasScrolledToInitial] = useState(false);
 
-  const activeTab = type || 'answers';
+  const activeTab = normalizeStreamTab(type);
 
   const { height: screenHeight } = useWindowDimensions();
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [isSharing, setIsSharing] = useState(false);
-  const [selectedAnswer, setSelectedAnswer] = useState<any>(null);
+  const [selectedAnswer, setSelectedAnswer] =
+    useState<StreamContentItem | null>(null);
 
   const footerAnim = useRef(new Animated.Value(0)).current;
   const isFloatingShown = useRef(false);
   const lastCheckTime = useRef(0);
-  const itemRefs = useRef(new Map<string, any>());
+  const itemRefs = useRef(new Map<string, StreamItemHandle | null>());
   const itemLayouts = useRef(new Map<string, { y: number; height: number }>());
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
 
-  const [activeItem, setActiveItem] = useState<any>(null);
+  const [activeItem, setActiveItem] = useState<StreamContentItem | null>(null);
   const viewableIdsRef = useRef<string[]>([]);
   const viewabilityConfig = useRef({
     viewAreaCoveragePercentThreshold: 20,
   }).current;
 
-  const onViewableItemsChanged = useRef(({ viewableItems }: any) => {
-    const ids: string[] = [];
-    let firstActive: any = null;
+  const onViewableItemsChanged = useRef(
+    ({ viewableItems }: { viewableItems: ViewToken<StreamApiItem>[] }) => {
+      const ids: string[] = [];
+      let firstActive: StreamContentItem | null = null;
 
-    viewableItems.forEach((v: any) => {
-      if (v.item) {
-        let displayItem = v.item;
-        if (activeTab === 'activities') displayItem = v.item.target || v.item;
-        if (displayItem?.id) {
-          const idStr = displayItem.id.toString();
-          ids.push(idStr);
-          if (!firstActive) {
-            firstActive = displayItem;
+      viewableItems.forEach((viewToken) => {
+        if (viewToken.item) {
+          const displayItem = getDisplayItem(viewToken.item, activeTab);
+          if (displayItem) {
+            const idStr = displayItem.id.toString();
+            ids.push(idStr);
+            if (!firstActive) {
+              firstActive = displayItem;
+            }
           }
         }
+      });
+
+      viewableIdsRef.current = ids;
+      if (firstActive) {
+        setActiveItem(firstActive);
       }
-    });
+    },
+  ).current;
 
-    viewableIdsRef.current = ids;
-    if (firstActive) {
-      setActiveItem(firstActive);
-    }
-  }).current;
-
-  const handleScroll = (event: any) => {
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const currentY = event.nativeEvent.contentOffset.y;
     const now = Date.now();
 
@@ -523,20 +601,14 @@ export default function UserStreamScreen() {
   };
 
   // 1. Fetch User Profile Details
-  const { data: user } = useQuery({
+  const {
+    data: user,
+    isLoading: isUserLoading,
+    isError: isUserError,
+    refetch: refetchUser,
+  } = useQuery({
     queryKey: ['user-detail', id],
-    queryFn: async () => {
-      try {
-        return await getMember(id as string);
-      } catch (err: any) {
-        if (err.response?.status === 403)
-          return await getMember(
-            id as string,
-            'follower_count,headline,cover_url,description,answer_count,articles_count,question_count,pins_count',
-          );
-        return null;
-      }
-    },
+    queryFn: () => getMemberWithFallback(id),
   });
 
   // 2. Infinite Query for specific content type stream
@@ -546,45 +618,42 @@ export default function UserStreamScreen() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isError: isStreamError,
+    refetch: refetchStream,
   } = useInfiniteQuery({
     queryKey: ['user-stream', id, activeTab],
-    queryFn: async ({ pageParam = 0 }) => {
-      try {
-        const targetId = user?.url_token || id;
-        if (activeTab === 'activities')
-          return await getMemberActivities(targetId, 10, pageParam as number);
-
-        let include = '';
-        if (activeTab === 'answers')
-          include =
-            'data[*].content,data[*].voteup_count,data[*].comment_count,data[*].created_time,data[*].updated_time,data[*].excerpt,data[*].question.title,data[*].relationship.voting,data[*].relationship.is_thanked';
-        else if (activeTab === 'questions')
-          include =
-            'data[*].created,data[*].answer_count,data[*].follower_count,data[*].author,data[*].admin_closed_comment,data[*].relationship.is_following';
-        else if (activeTab === 'articles')
-          include =
-            'data[*].comment_count,data[*].content,data[*].voteup_count,data[*].created,data[*].updated,data[*].title,data[*].excerpt,data[*].relationship.voting';
-        else if (activeTab === 'pins')
-          include =
-            'data[*].content,data[*].reaction_count,data[*].comment_count,data[*].created,data[*].relationship.voting';
-
-        return await getMemberRelations(targetId, activeTab as any, {
-          limit: 10,
-          offset: pageParam as number,
-          include,
-        });
-      } catch (err) {
-        console.error(`获取${activeTab}流失败:`, err);
-        return { data: [], paging: { is_end: true } };
+    queryFn: ({ pageParam = 0 }) => {
+      const targetId = user?.url_token || id;
+      if (activeTab === 'activities') {
+        return getMemberActivities(targetId, 10, pageParam);
       }
+
+      let include = '';
+      if (activeTab === 'answers')
+        include =
+          'data[*].content,data[*].voteup_count,data[*].comment_count,data[*].created_time,data[*].updated_time,data[*].excerpt,data[*].question.title,data[*].relationship.voting,data[*].relationship.is_thanked';
+      else if (activeTab === 'questions')
+        include =
+          'data[*].created,data[*].answer_count,data[*].follower_count,data[*].author,data[*].admin_closed_comment,data[*].relationship.is_following';
+      else if (activeTab === 'articles')
+        include =
+          'data[*].comment_count,data[*].content,data[*].voteup_count,data[*].created,data[*].updated,data[*].title,data[*].excerpt,data[*].relationship.voting';
+      else if (activeTab === 'pins')
+        include =
+          'data[*].content,data[*].reaction_count,data[*].comment_count,data[*].created,data[*].relationship.voting';
+
+      return getMemberRelations(targetId, activeTab, {
+        limit: 10,
+        offset: pageParam,
+        include,
+      });
     },
-    initialPageParam: 0 as number | string,
+    initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
-      const match = lastPage.paging?.next?.match(/offset=(\d+)/);
-      return match ? match[1] : undefined;
+      return getNextPageOffset(lastPage.paging?.next);
     },
-    enabled: user !== undefined,
+    enabled: !!user,
   });
 
   const streamItems =
@@ -594,9 +663,8 @@ export default function UserStreamScreen() {
   useEffect(() => {
     if (initialId && streamItems.length > 0 && !hasScrolledToInitial) {
       const index = streamItems.findIndex((item) => {
-        const displayItem =
-          activeTab === 'activities' ? item.target || item : item;
-        return displayItem?.id?.toString() === initialId?.toString();
+        const displayItem = getDisplayItem(item, activeTab);
+        return displayItem?.id.toString() === initialId.toString();
       });
       if (index !== -1) {
         setHasScrolledToInitial(true);
@@ -636,11 +704,9 @@ export default function UserStreamScreen() {
 
         // Collapsing: scroll back to the item to prevent losing context
         setTimeout(() => {
-          const index = streamItems.findIndex((item: any) => {
-            let displayItem = item;
-            if (activeTab === 'activities') displayItem = item.target || item;
-            return displayItem?.id?.toString() === id;
-          });
+          const index = streamItems.findIndex(
+            (item) => getDisplayItem(item, activeTab)?.id.toString() === id,
+          );
           if (index >= 0) {
             flashListRef.current?.scrollToIndex({
               index: index,
@@ -654,10 +720,9 @@ export default function UserStreamScreen() {
     [streamItems, activeTab, insets.top],
   );
 
-  const renderItemContent = ({ item }: { item: any; index: number }) => {
-    let displayItem = item as any;
-    if (activeTab === 'activities') displayItem = item.target || item;
-    if (!displayItem || (!displayItem.id && !displayItem.url)) return null;
+  const renderItemContent = ({ item }: ListRenderItemInfo<StreamApiItem>) => {
+    const displayItem = getDisplayItem(item, activeTab);
+    if (!displayItem) return null;
 
     let itemType: 'answer' | 'article' | 'question' | 'pin' | 'video' =
       'answer';
@@ -688,26 +753,18 @@ export default function UserStreamScreen() {
       >
         <StreamItem
           ref={(r) => {
-            displayItem?.id
-              ? itemRefs.current.set(displayItem.id.toString(), r)
-              : itemRefs.current.delete(displayItem.id?.toString() || '');
+            itemRefs.current.set(displayItem.id.toString(), r);
           }}
           item={displayItem}
           type={itemType}
-          isExpanded={
-            displayItem?.id ? expandedIds.has(displayItem.id.toString()) : false
-          }
+          isExpanded={expandedIds.has(displayItem.id.toString())}
           onToggle={handleToggleExpand}
           onShare={(ans) => {
             setSelectedAnswer(ans);
             setIsSharing(true);
           }}
           isHighlighted={!!isHighlighted}
-          isCollapsedHighlighted={
-            displayItem?.id
-              ? highlightedId === displayItem.id.toString()
-              : false
-          }
+          isCollapsedHighlighted={highlightedId === displayItem.id.toString()}
         />
       </View>
     );
@@ -730,239 +787,280 @@ export default function UserStreamScreen() {
       }}
     >
       <Stack.Screen options={{ headerShown: false }} />
-      {/* 1. Header Bar */}
-      <View
-        className="flex-row items-center px-4 py-3 border-b border-gray-100 dark:border-gray-800"
-        style={{
-          paddingTop: insets.top,
-          backgroundColor: Colors[colorScheme].background,
-        }}
-      >
-        <BouncyButton
-          onPress={() => router.back()}
-          className="p-1 -ml-1 bg-transparent"
-        >
-          <Ionicons
-            name="chevron-back"
-            size={24}
-            color={Colors[colorScheme].text}
-          />
-        </BouncyButton>
-
-        {/* User Mini Profile */}
-        <Pressable
-          onPress={() => router.push(`/user/${user?.url_token || id}`)}
-          className="flex-row items-center ml-2 flex-1 bg-transparent"
-        >
-          <Image
-            source={{
-              uri:
-                user?.avatar_url ||
-                'https://picx.zhimg.com/v2-abed1a8c04702bc9e7ba3d3d82bc7591_l.jpg',
-            }}
-            className="w-8 h-8 rounded-full"
-          />
-          <View className="ml-2 bg-transparent flex-1">
-            <Text className="font-bold text-sm" numberOfLines={1}>
-              {user?.name || '加载中...'}
-            </Text>
-            <Text type="secondary" className="text-[11px]" numberOfLines={1}>
-              {user?.headline || '查看全部个人主页'}
-            </Text>
-          </View>
-        </Pressable>
-
-        {/* Content Type Badge */}
-        <View
-          className="px-2.5 py-1 rounded-full ml-2"
-          style={{ backgroundColor: 'rgba(0,132,255,0.08)' }}
-        >
-          <Text type="primary" className="text-xs font-bold">
-            {getTypeName()}流
-          </Text>
+      {isUserLoading ? (
+        <View className="flex-1 items-center justify-center bg-transparent">
+          <ActivityIndicator color={primaryColor} />
         </View>
-      </View>
-
-      {/* 2. Content Stream List */}
-      <FlashList
-        ref={flashListRef}
-        onScroll={handleScroll}
-        data={streamItems}
-        {...({ estimatedItemSize: 250 } as any)}
-        keyExtractor={(item: any, index: number) =>
-          `stream-${item.id || ''}-${index}`
-        }
-        renderItem={renderItemContent}
-        onViewableItemsChanged={onViewableItemsChanged}
-        viewabilityConfig={viewabilityConfig}
-        onEndReached={() => {
-          if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-        }}
-        onEndReachedThreshold={0.5}
-        contentContainerStyle={{ paddingVertical: 10, paddingBottom: 50 }}
-        ListEmptyComponent={
-          streamLoading ? (
-            <ActivityIndicator
-              style={{ marginTop: 100 }}
-              color={primaryColor}
-            />
-          ) : (
-            <Text type="secondary" className="text-center mt-20 text-sm">
-              暂无内容流 喵~
-            </Text>
-          )
-        }
-        ListFooterComponent={
-          isFetchingNextPage ? (
-            <ActivityIndicator style={{ margin: 20 }} color={primaryColor} />
-          ) : streamItems.length > 0 && !hasNextPage ? (
-            <Text type="secondary" className="text-center p-5 text-xs">
-              — 已经到底了喵 —
-            </Text>
-          ) : null
-        }
-      />
-
-      <ShareMenu
-        visible={isSharing}
-        onClose={() => {
-          setIsSharing(false);
-          setSelectedAnswer(null);
-        }}
-        type={
-          selectedAnswer?.type === 'article'
-            ? 'article'
-            : selectedAnswer?.type === 'pin'
-              ? 'pin'
-              : 'answer'
-        }
-        data={
-          selectedAnswer
-            ? {
-                id: selectedAnswer.id,
-                title:
-                  selectedAnswer.title ||
-                  selectedAnswer.question?.title ||
-                  '想法',
-                author: selectedAnswer.author?.name || user?.name,
-                authorHeadline:
-                  selectedAnswer.author?.headline || user?.headline,
-                content: selectedAnswer.excerpt || selectedAnswer.content || '',
-              }
-            : null
-        }
-      />
-
-      <Animated.View
-        className="absolute left-5 right-5 h-[54px] rounded-[27px] overflow-hidden z-[1000] shadow-black/20 shadow-lg elevation-10"
-        style={[
-          {
-            bottom: insets.bottom,
-            transform: [
-              {
-                translateY: footerAnim.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [100, 0],
-                }),
-              },
-            ],
-            opacity: footerAnim,
-          },
-        ]}
-      >
-        <BlurView
-          intensity={95}
-          tint={colorScheme}
-          className="flex-1"
-          style={{
-            backgroundColor:
-              colorScheme === 'dark'
-                ? 'rgba(26,26,26,0.8)'
-                : 'rgba(255,255,255,0.85)',
-          }}
-        >
-          <View className="flex-1 flex-row items-center px-5 justify-between bg-transparent">
-            <View className="flex-row items-center bg-transparent">
-              <LikeButton
-                id={activeItem?.id}
-                count={
-                  activeItem?.reaction?.statistics?.like_count ||
-                  activeItem?.voteup_count ||
-                  activeItem?.reaction_count ||
-                  0
-                }
-                voted={activeItem?.relationship?.voting || 0}
-                type={
-                  activeItem?.type === 'article'
-                    ? 'articles'
-                    : activeItem?.type === 'pin'
-                      ? 'pins'
-                      : 'answers'
-                }
-                variant="ghost"
+      ) : isUserError || !user ? (
+        <QueryErrorView
+          message="用户资料加载失败"
+          onRetry={() => void refetchUser()}
+        />
+      ) : (
+        <>
+          {/* 1. Header Bar */}
+          <View
+            className="flex-row items-center px-4 py-3 border-b border-gray-100 dark:border-gray-800"
+            style={{
+              paddingTop: insets.top,
+              backgroundColor: Colors[colorScheme].background,
+            }}
+          >
+            <BouncyButton
+              onPress={() => router.back()}
+              className="p-1 -ml-1 bg-transparent"
+            >
+              <Ionicons
+                name="chevron-back"
+                size={24}
+                color={Colors[colorScheme].text}
               />
-              <Pressable
-                className="flex-row items-center ml-5 bg-transparent"
-                onPress={() => {
-                  const commentType =
-                    activeItem?.type === 'article'
-                      ? 'article'
-                      : activeItem?.type === 'pin'
-                        ? 'pin'
-                        : 'answer';
-                  router.push(
-                    `/comments/${activeItem?.id}?type=${commentType}&count=${activeItem?.comment_count || 0}`,
-                  );
+            </BouncyButton>
+
+            {/* User Mini Profile */}
+            <Pressable
+              onPress={() => router.push(`/user/${user?.url_token || id}`)}
+              className="flex-row items-center ml-2 flex-1 bg-transparent"
+            >
+              <Image
+                source={{
+                  uri:
+                    user?.avatar_url ||
+                    'https://picx.zhimg.com/v2-abed1a8c04702bc9e7ba3d3d82bc7591_l.jpg',
                 }}
-              >
-                <Ionicons
-                  name="chatbubble-outline"
-                  size={20}
+                className="w-8 h-8 rounded-full"
+              />
+              <View className="ml-2 bg-transparent flex-1">
+                <Text className="font-bold text-sm" numberOfLines={1}>
+                  {user?.name || '加载中...'}
+                </Text>
+                <Text
+                  type="secondary"
+                  className="text-[11px]"
+                  numberOfLines={1}
+                >
+                  {user?.headline || '查看全部个人主页'}
+                </Text>
+              </View>
+            </Pressable>
+
+            {/* Content Type Badge */}
+            <View
+              className="px-2.5 py-1 rounded-full ml-2"
+              style={{ backgroundColor: 'rgba(0,132,255,0.08)' }}
+            >
+              <Text type="primary" className="text-xs font-bold">
+                {getTypeName()}流
+              </Text>
+            </View>
+          </View>
+
+          {/* 2. Content Stream List */}
+          <FlashList<StreamApiItem>
+            ref={flashListRef}
+            onScroll={handleScroll}
+            data={streamItems}
+            keyExtractor={(item) => {
+              const displayItem = getDisplayItem(item, activeTab);
+              return `stream-${displayItem?.id ?? item.url ?? 'unknown'}`;
+            }}
+            renderItem={renderItemContent}
+            onViewableItemsChanged={onViewableItemsChanged}
+            viewabilityConfig={viewabilityConfig}
+            onEndReached={() => {
+              if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+            }}
+            onEndReachedThreshold={0.5}
+            contentContainerStyle={{ paddingVertical: 10, paddingBottom: 50 }}
+            ListEmptyComponent={
+              streamLoading ? (
+                <ActivityIndicator
+                  style={{ marginTop: 100 }}
                   color={primaryColor}
                 />
-                <Text
-                  type="primary"
-                  className=" text-sm font-bold"
-                  style={{ color: primaryColor }}
-                >
-                  {activeItem?.comment_count || 0}
+              ) : isStreamError ? (
+                <QueryErrorView
+                  message="内容流加载失败"
+                  onRetry={() => void refetchStream()}
+                />
+              ) : (
+                <Text type="secondary" className="text-center mt-20 text-sm">
+                  暂无内容流 喵~
                 </Text>
-              </Pressable>
+              )
+            }
+            ListFooterComponent={
+              isFetchingNextPage ? (
+                <ActivityIndicator
+                  style={{ margin: 20 }}
+                  color={primaryColor}
+                />
+              ) : streamItems.length > 0 && !hasNextPage ? (
+                <Text type="secondary" className="text-center p-5 text-xs">
+                  — 已经到底了喵 —
+                </Text>
+              ) : null
+            }
+          />
 
-              {activeItem?.id && expandedIds.has(activeItem.id.toString()) && (
-                <Pressable
-                  className="flex-row items-center ml-5 bg-transparent"
-                  onPress={() =>
-                    handleToggleExpand(activeItem.id.toString(), false)
+          <ShareMenu
+            visible={isSharing}
+            onClose={() => {
+              setIsSharing(false);
+              setSelectedAnswer(null);
+            }}
+            type={
+              selectedAnswer?.type === 'article'
+                ? 'article'
+                : selectedAnswer?.type === 'pin'
+                  ? 'pin'
+                  : selectedAnswer?.type === 'question'
+                    ? 'question'
+                    : selectedAnswer?.type === 'zvideo' ||
+                        selectedAnswer?.type === 'video'
+                      ? 'video'
+                      : 'answer'
+            }
+            data={
+              selectedAnswer
+                ? {
+                    id: selectedAnswer.id,
+                    title:
+                      selectedAnswer.title ||
+                      selectedAnswer.question?.title ||
+                      '想法',
+                    author: selectedAnswer.author?.name || user?.name,
+                    authorHeadline:
+                      selectedAnswer.author?.headline || user?.headline,
+                    content:
+                      selectedAnswer.excerpt ||
+                      (typeof selectedAnswer.content === 'string'
+                        ? selectedAnswer.content
+                        : ''),
                   }
-                >
-                  <Ionicons
-                    name="chevron-up-circle-outline"
-                    size={20}
-                    color={primaryColor}
-                  />
-                  <Text
-                    type="primary"
-                    className=" text-sm font-bold"
-                    style={{ color: primaryColor }}
-                  >
-                    收起
-                  </Text>
-                </Pressable>
-              )}
-            </View>
-            <Pressable
-              className="flex-row items-center bg-transparent"
-              onPress={() => {
-                setSelectedAnswer(activeItem);
-                setIsSharing(true);
+                : null
+            }
+          />
+
+          <Animated.View
+            className="absolute left-5 right-5 h-[54px] rounded-[27px] overflow-hidden z-[1000] shadow-black/20 shadow-lg elevation-10"
+            style={[
+              {
+                bottom: insets.bottom,
+                transform: [
+                  {
+                    translateY: footerAnim.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [100, 0],
+                    }),
+                  },
+                ],
+                opacity: footerAnim,
+              },
+            ]}
+          >
+            <BlurView
+              intensity={95}
+              tint={colorScheme}
+              className="flex-1"
+              style={{
+                backgroundColor:
+                  colorScheme === 'dark'
+                    ? 'rgba(26,26,26,0.8)'
+                    : 'rgba(255,255,255,0.85)',
               }}
             >
-              <Ionicons name="share-outline" size={22} color={primaryColor} />
-            </Pressable>
-          </View>
-        </BlurView>
-      </Animated.View>
+              <View className="flex-1 flex-row items-center px-5 justify-between bg-transparent">
+                <View className="flex-row items-center bg-transparent">
+                  {activeItem && (
+                    <LikeButton
+                      id={activeItem.id}
+                      count={
+                        activeItem.reaction?.statistics?.like_count ||
+                        activeItem.voteup_count ||
+                        activeItem.reaction_count ||
+                        0
+                      }
+                      voted={activeItem.relationship?.voting || 0}
+                      type={
+                        activeItem.type === 'article'
+                          ? 'articles'
+                          : activeItem.type === 'pin'
+                            ? 'pins'
+                            : 'answers'
+                      }
+                      variant="ghost"
+                    />
+                  )}
+                  <Pressable
+                    className="flex-row items-center ml-5 bg-transparent"
+                    onPress={() => {
+                      const commentType =
+                        activeItem?.type === 'article'
+                          ? 'article'
+                          : activeItem?.type === 'pin'
+                            ? 'pin'
+                            : 'answer';
+                      router.push(
+                        `/comments/${activeItem?.id}?type=${commentType}&count=${activeItem?.comment_count || 0}`,
+                      );
+                    }}
+                  >
+                    <Ionicons
+                      name="chatbubble-outline"
+                      size={20}
+                      color={primaryColor}
+                    />
+                    <Text
+                      type="primary"
+                      className=" text-sm font-bold"
+                      style={{ color: primaryColor }}
+                    >
+                      {activeItem?.comment_count || 0}
+                    </Text>
+                  </Pressable>
+
+                  {activeItem?.id &&
+                    expandedIds.has(activeItem.id.toString()) && (
+                      <Pressable
+                        className="flex-row items-center ml-5 bg-transparent"
+                        onPress={() =>
+                          handleToggleExpand(activeItem.id.toString(), false)
+                        }
+                      >
+                        <Ionicons
+                          name="chevron-up-circle-outline"
+                          size={20}
+                          color={primaryColor}
+                        />
+                        <Text
+                          type="primary"
+                          className=" text-sm font-bold"
+                          style={{ color: primaryColor }}
+                        >
+                          收起
+                        </Text>
+                      </Pressable>
+                    )}
+                </View>
+                <Pressable
+                  className="flex-row items-center bg-transparent"
+                  onPress={() => {
+                    setSelectedAnswer(activeItem);
+                    setIsSharing(true);
+                  }}
+                >
+                  <Ionicons
+                    name="share-outline"
+                    size={22}
+                    color={primaryColor}
+                  />
+                </Pressable>
+              </View>
+            </BlurView>
+          </Animated.View>
+        </>
+      )}
     </View>
   );
 }

--- a/app/user/likes.tsx
+++ b/app/user/likes.tsx
@@ -5,10 +5,12 @@ import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { getMyLikes } from '@/api/zhihu';
 import { CreationCard } from '@/components/CreationCard';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
 import { useZhihuInfiniteQuery } from '@/hooks/useZhihuInfiniteQuery';
+import type { ZhihuMemberRelation } from '@/types/zhihu';
 import { refreshInfiniteQuery } from '@/utils/query';
 
 export default function MyLikesScreen() {
@@ -29,6 +31,7 @@ export default function MyLikesScreen() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isError,
     refetch,
     isRefetching,
   } = useZhihuInfiniteQuery({
@@ -42,7 +45,7 @@ export default function MyLikesScreen() {
     return refreshInfiniteQuery(queryClient, ['my-likes', activeTab], refetch);
   }, [queryClient, activeTab, refetch]);
 
-  const listItems = data?.pages.flatMap((page: any) => page.data) || [];
+  const listItems = data?.pages.flatMap((page) => page.data) || [];
 
   return (
     <View className="flex-1">
@@ -87,15 +90,15 @@ export default function MyLikesScreen() {
         </Pressable>
       </View>
 
-      <FlashList
+      <FlashList<ZhihuMemberRelation>
         data={listItems}
-        renderItem={({ item }: { item: any }) => (
+        keyExtractor={(item) => String(item.id)}
+        renderItem={({ item }) => (
           <CreationCard
             item={item}
             type={activeTab === 'answers' ? 'answer' : 'article'}
           />
         )}
-        {...({ estimatedItemSize: 150 } as any)}
         onEndReached={() => {
           if (hasNextPage && !isFetchingNextPage) fetchNextPage();
         }}
@@ -105,6 +108,12 @@ export default function MyLikesScreen() {
           <View className="flex-1 p-[100px] items-center">
             {isLoading ? (
               <ActivityIndicator color={primaryColor} />
+            ) : isError ? (
+              <QueryErrorView
+                compact
+                message="点赞内容加载失败"
+                onRetry={() => void handleRefresh()}
+              />
             ) : (
               <Text type="secondary">还没有点赞过内容喵</Text>
             )}

--- a/app/video/[id].tsx
+++ b/app/video/[id].tsx
@@ -1,0 +1,40 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { ActivityIndicator } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { Text, useThemeColor, View } from '@/components/Themed';
+
+export default function VideoDetailScreen() {
+  const { id, title } = useLocalSearchParams<{
+    id: string;
+    title?: string;
+  }>();
+  const primaryColor = useThemeColor({}, 'primary');
+
+  if (!id) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <Stack.Screen options={{ title: '视频' }} />
+        <Text type="secondary">无效的视频地址</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1">
+      <Stack.Screen options={{ title: title || '视频' }} />
+      <WebView
+        source={{
+          uri: `https://www.zhihu.com/zvideo/${encodeURIComponent(id)}`,
+        }}
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
+        startInLoadingState
+        renderLoading={() => (
+          <View className="absolute inset-0 items-center justify-center">
+            <ActivityIndicator color={primaryColor} />
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/components/CreationCard.tsx
+++ b/components/CreationCard.tsx
@@ -14,7 +14,70 @@ import { BouncyButton } from './BouncyButton';
 import { LikeButton } from './LikeButton';
 import { type ShareContentType, ShareMenu } from './ShareMenu';
 
-export const CreationCard = React.forwardRef(
+type CreationType = 'answer' | 'article' | 'question' | 'pin' | 'video';
+
+interface CreationContentSegment {
+  type: string;
+  content?: string;
+  data_draft_title?: string;
+}
+
+interface CreationItem {
+  id: string | number;
+  type?: string;
+  title?: string;
+  titleString?: string;
+  content?: string | CreationContentSegment[];
+  excerpt?: string;
+  url?: string;
+  voteCount?: number;
+  voteup_count?: number;
+  voted?: number;
+  reaction_count?: number;
+  like_count?: number;
+  comment_count?: number;
+  favlists_count?: number;
+  favlistsCount?: number;
+  favorite_count?: number;
+  answer_count?: number;
+  follower_count?: number;
+  created?: number;
+  created_time?: number;
+  updated?: number;
+  updated_time?: number;
+  question?: {
+    id?: string | number;
+    title?: string;
+    titleString?: string;
+  };
+  author?: { name?: string; headline?: string };
+  relationship?: { voting?: number };
+  reaction?: {
+    statistics?: { favorites?: number; like_count?: number };
+  };
+}
+
+interface CreationCardProps {
+  item: CreationItem;
+  type: CreationType;
+  onPress?: () => void;
+  excerpt?: React.ReactNode;
+  isExpanded?: boolean;
+  onToggle?: (id: string, expanded: boolean) => void;
+  isCollapsedHighlighted?: boolean;
+}
+
+interface CreationCardHandle {
+  measureFooter: (
+    callback: (x: number, y: number, width: number, height: number) => void,
+  ) => void;
+  id: string;
+}
+
+export const CreationCard = React.forwardRef<
+  CreationCardHandle,
+  CreationCardProps
+>(
   (
     {
       item,
@@ -24,15 +87,7 @@ export const CreationCard = React.forwardRef(
       isExpanded,
       onToggle,
       isCollapsedHighlighted,
-    }: {
-      item: any;
-      type: 'answer' | 'article' | 'question' | 'pin' | 'video';
-      onPress?: () => void;
-      excerpt?: React.ReactNode;
-      isExpanded?: boolean;
-      onToggle?: (id: string, expanded: boolean) => void;
-      isCollapsedHighlighted?: boolean;
-    },
+    }: CreationCardProps,
     ref,
   ) => {
     const router = useRouter();
@@ -60,8 +115,8 @@ export const CreationCard = React.forwardRef(
     const { toggleCollect } = useCollectionAction();
 
     React.useImperativeHandle(ref, () => ({
-      measureFooter: (cb: any) => footerRef.current?.measureInWindow(cb),
-      id: item?.id?.toString() || Math.random().toString(),
+      measureFooter: (callback) => footerRef.current?.measureInWindow(callback),
+      id: item.id.toString(),
     }));
 
     const expanded = isExpanded !== undefined ? isExpanded : localExpanded;
@@ -79,8 +134,8 @@ export const CreationCard = React.forwardRef(
         return;
       }
       if (excerpt !== undefined) {
-        const cleanTitle = (val: any) => {
-          if (typeof val === 'string') return val;
+        const cleanTitle = (value: unknown) => {
+          if (typeof value === 'string') return value;
           if (item.titleString) return item.titleString;
           if (item.question?.titleString) return item.question.titleString;
           return '';
@@ -89,7 +144,7 @@ export const CreationCard = React.forwardRef(
           router.push({
             pathname: '/video/[id]',
             params: { id: item.id, title: cleanTitle(item.title) },
-          } as any);
+          });
         } else {
           router.push({
             pathname: `/${type}/[id]`,
@@ -98,7 +153,7 @@ export const CreationCard = React.forwardRef(
               title: cleanTitle(item.title || item.question?.title),
               questionId: item.question?.id,
             },
-          } as any);
+          });
         }
         return;
       }
@@ -112,10 +167,10 @@ export const CreationCard = React.forwardRef(
       if (!item) return '';
       if (type === 'pin' && Array.isArray(item.content)) {
         return item.content
-          .map((c: any) => {
-            if (c.type === 'text') return c.content;
-            if (c.type === 'link_card')
-              return `[链接: ${c.data_draft_title || '查看详情'}]`;
+          .map((segment) => {
+            if (segment.type === 'text') return segment.content;
+            if (segment.type === 'link_card')
+              return `[链接: ${segment.data_draft_title || '查看详情'}]`;
             return '';
           })
           .join('\n')
@@ -135,8 +190,8 @@ export const CreationCard = React.forwardRef(
       if (type === 'pin') {
         if (Array.isArray(item.content)) {
           return item.content
-            .filter((c: any) => c.type === 'text')
-            .map((c: any) => c.content)
+            .filter((segment) => segment.type === 'text')
+            .map((segment) => segment.content)
             .join('')
             .replace(/<[^>]+>/g, '')
             .substring(0, 100);
@@ -167,8 +222,10 @@ export const CreationCard = React.forwardRef(
         (typeof item.content === 'string' &&
           (item.content.includes('<img') || item.content.includes('<figure'))));
 
-    const displayTypeForShare =
-      type === 'answer' ? 'answer' : type === 'article' ? 'article' : 'pin';
+    const displayTypeForShare: ShareContentType = type;
+    const timestamp =
+      item.updated_time ?? item.updated ?? item.created_time ?? item.created;
+    const shareExcerpt = getExcerpt();
 
     return (
       <BouncyButton
@@ -378,7 +435,7 @@ export const CreationCard = React.forwardRef(
               >
                 <Ionicons name="chatbubble-outline" size={16} color="#888" />
                 <Text className="ml-1 text-xs font-semibold">
-                  {item.comment_count > 0 ? item.comment_count : '0'}
+                  {(item.comment_count ?? 0) > 0 ? item.comment_count : '0'}
                 </Text>
               </Pressable>
               {isCollectable && (
@@ -420,17 +477,7 @@ export const CreationCard = React.forwardRef(
               type="secondary"
               className="text-xs text-tertiary dark:text-tertiary-dark mr-3"
             >
-              {item.updated_time ||
-              item.updated ||
-              item.created_time ||
-              item.created
-                ? new Date(
-                    (item.updated_time ||
-                      item.updated ||
-                      item.created_time ||
-                      item.created) * 1000,
-                  ).toLocaleDateString()
-                : ''}
+              {timestamp ? new Date(timestamp * 1000).toLocaleDateString() : ''}
             </Text>
             <BouncyButton
               onPress={() => setMenuVisible(true)}
@@ -444,16 +491,16 @@ export const CreationCard = React.forwardRef(
         <ShareMenu
           visible={menuVisible}
           onClose={() => setMenuVisible(false)}
-          type={displayTypeForShare as ShareContentType}
-          data={
-            {
-              id: item.id,
-              title: getTitle(),
-              author: item.author?.name,
-              authorHeadline: item.author?.headline,
-              excerpt: getExcerpt(),
-            } as any
-          }
+          type={displayTypeForShare}
+          data={{
+            id: item.id,
+            title: getTitle(),
+            author: item.author?.name,
+            authorHeadline: item.author?.headline,
+            excerpt:
+              typeof shareExcerpt === 'string' ? shareExcerpt : undefined,
+            url: item.url,
+          }}
         />
       </BouncyButton>
     );

--- a/components/FeedCard.tsx
+++ b/components/FeedCard.tsx
@@ -27,6 +27,11 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
   const [menuVisible, setMenuVisible] = useState(false);
   const isQuestionType = item.type === 'questions';
   const isPinType = item.type === 'pins';
+  const isVideoType = item.type === 'videos';
+  const engagementType: 'answers' | 'articles' | 'pins' | null =
+    item.type === 'answers' || item.type === 'articles' || item.type === 'pins'
+      ? item.type
+      : null;
   const isGuest = !cookies;
   const colorScheme = useColorScheme();
 
@@ -52,6 +57,47 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
   const warningColor = useThemeColor({}, 'warning');
   const secondaryColor = useThemeColor({}, 'textSecondary');
 
+  const cleanTitle =
+    typeof item.title === 'string' ? item.title : item.titleString || '';
+  const openDetail = () => {
+    if (isVideoType) {
+      router.push({
+        pathname: '/video/[id]',
+        params: { id: item.id, title: cleanTitle },
+      });
+      return;
+    }
+    if (isGuest) {
+      router.push({
+        pathname: '/guest/detail',
+        params: {
+          item: JSON.stringify({
+            ...item,
+            title: cleanTitle,
+            excerpt: typeof item.excerpt === 'string' ? item.excerpt : '',
+          }),
+        },
+      });
+      return;
+    }
+
+    const params = {
+      id: item.id,
+      title: cleanTitle,
+      questionId: item.questionId,
+      ...(tab ? { source: 'feed', tab } : {}),
+    };
+    if (item.type === 'answers') {
+      router.push({ pathname: '/answer/[id]', params });
+    } else if (item.type === 'articles') {
+      router.push({ pathname: '/article/[id]', params });
+    } else if (item.type === 'pins') {
+      router.push({ pathname: '/pin/[id]', params });
+    } else {
+      router.push({ pathname: '/question/[id]', params });
+    }
+  };
+
   const [previewVisible, setPreviewVisible] = useState(false);
   const containerRef = useRef<RNView>(null);
   const [originLayout, setOriginLayout] = useState<{
@@ -62,7 +108,7 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
   } | null>(null);
 
   const menuOptions: MenuOption[] = [
-    ...(!isQuestionType
+    ...(engagementType
       ? [
           {
             key: 'like',
@@ -80,12 +126,12 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
                     : nextVoted === 1
                       ? 'up'
                       : 'neutral';
-                await voteContent(item.id, item.type, voteType as any);
+                await voteContent(item.id, engagementType, voteType);
                 setVoted(nextVoted);
                 setVoteCount(nextCount);
                 showToast(nextVoted === 1 ? '已赞同' : '已取消赞同');
-              } catch (err) {
-                console.error('投票失败:', err);
+              } catch {
+                console.error('投票失败');
                 showToast('操作失败，请稍后重试');
               }
             },
@@ -127,12 +173,12 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
       icon: 'share-outline',
       onPress: async () => {
         try {
-          const routeType = item.type.slice(0, -1);
+          const routeType = isVideoType ? 'zvideo' : item.type.slice(0, -1);
           const link = `https://www.zhihu.com/${routeType}/${item.id}`;
           await Share.share({
             message: link,
             url: link,
-            title: item.title || '知乎分享',
+            title: cleanTitle || '知乎分享',
           });
         } catch (_error) {
           showToast('分享失败');
@@ -145,7 +191,7 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
     <RNView ref={containerRef} className="w-full bg-transparent">
       <BouncyButton
         onLongPress={() => {
-          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+          void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
           containerRef.current?.measureInWindow(
             (x: number, y: number, width: number, height: number) => {
               setOriginLayout({ x, y, width, height });
@@ -153,32 +199,7 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
             },
           );
         }}
-        onPress={() => {
-          if (isGuest) {
-            router.push({
-              pathname: '/guest/detail',
-              params: { item: JSON.stringify(item) },
-            } as any);
-            return;
-          }
-          const routeType = item.type.slice(0, -1);
-          const cleanTitle =
-            typeof item.title === 'string'
-              ? item.title
-              : item.titleString || '';
-          const params: any = {
-            title: cleanTitle,
-            questionId: item.questionId,
-          };
-          if (tab) {
-            params.source = 'feed';
-            params.tab = tab;
-          }
-          router.push({
-            pathname: `/${routeType}/${item.id}`,
-            params,
-          } as any);
-        }}
+        onPress={openDetail}
         style={[
           {
             backgroundColor: Colors[colorScheme].backgroundSecondary,
@@ -203,9 +224,12 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
         <BouncyButton
           onPress={() =>
             router.push({
-              pathname: `/user/${item.author.url_token || item.author.id}`,
-              params: { avatar: item.author.avatar },
-            } as any)
+              pathname: '/user/[id]',
+              params: {
+                id: item.author.url_token || item.author.id,
+                avatar: item.author.avatar,
+              },
+            })
           }
           className="flex-row items-center mb-2"
         >
@@ -222,10 +246,15 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
         {/* 话题标签 */}
         {item.topics && item.topics.length > 0 && (
           <View className="flex-row flex-wrap mb-2 bg-transparent">
-            {item.topics.map((topic: any) => (
+            {item.topics.map((topic) => (
               <BouncyButton
                 key={topic.id}
-                onPress={() => router.push(`/topic/${topic.id}` as any)}
+                onPress={() =>
+                  router.push({
+                    pathname: '/topic/[id]',
+                    params: { id: topic.id },
+                  })
+                }
                 className="px-2 py-0.5 rounded-sm mr-2 mb-1"
                 style={{ backgroundColor: 'rgba(0,0,132,0.05)' }}
               >
@@ -241,34 +270,11 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
         {item.title ? (
           <BouncyButton
             onPress={() => {
-              if (isGuest) {
-                router.push({
-                  pathname: '/guest/detail',
-                  params: { item: JSON.stringify(item) },
-                } as any);
-                return;
-              }
               if (item.type === 'answers' && item.questionId) {
                 router.push(`/question/${item.questionId}`);
                 return;
               }
-              const routeType = item.type.slice(0, -1);
-              const cleanTitle =
-                typeof item.title === 'string'
-                  ? item.title
-                  : item.titleString || '';
-              const params: any = {
-                title: cleanTitle,
-                questionId: item.questionId,
-              };
-              if (tab) {
-                params.source = 'feed';
-                params.tab = tab;
-              }
-              router.push({
-                pathname: `/${routeType}/${item.id}`,
-                params,
-              } as any);
+              openDetail();
             }}
           >
             <Animated.View
@@ -290,7 +296,7 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
         <View className="flex-row mt-1 bg-transparent">
           <View className="flex-1 bg-transparent">
             {isPinType && Array.isArray(item.content) ? (
-              <FeedExcerpt contentArray={item.content as any[]} />
+              <FeedExcerpt contentArray={item.content} />
             ) : item.excerpt ? (
               <FeedExcerpt html={item.excerpt} />
             ) : null}
@@ -305,13 +311,13 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
         </View>
 
         {/* 热区4：底部操作栏 - 问题关注类动态不显示 */}
-        {!isQuestionType && (
-          <View className="flex-row items-center bg-transparen">
+        {engagementType && (
+          <View className="flex-row items-center bg-transparent">
             <LikeButton
               id={item.id}
               count={voteCount}
               voted={voted}
-              type={item.type as any}
+              type={engagementType}
               variant="ghost"
               onVoteChange={(newVoted, newCount) => {
                 setVoted(newVoted);
@@ -388,13 +394,19 @@ export const FeedCard = ({ item, tab }: { item: FeedItem; tab?: string }) => {
         <ShareMenu
           visible={menuVisible}
           onClose={() => setMenuVisible(false)}
-          type={item.type.slice(0, -1) as ShareContentType}
+          type={
+            (isVideoType ? 'video' : item.type.slice(0, -1)) as ShareContentType
+          }
           data={{
             id: item.id,
-            title: item.title,
+            title: cleanTitle,
             author: item.author?.name,
             authorHeadline: item.author?.headline,
-            excerpt: item.excerpt,
+            excerpt:
+              typeof item.excerpt === 'string' ? item.excerpt : undefined,
+            url: isVideoType
+              ? `https://www.zhihu.com/zvideo/${item.id}`
+              : undefined,
           }}
         />
       </BouncyButton>

--- a/components/FeedCardPreview.tsx
+++ b/components/FeedCardPreview.tsx
@@ -21,8 +21,20 @@ interface FeedCardPreviewProps {
   item: FeedItem;
 }
 
+function getResponseStatus(error: unknown) {
+  if (!error || typeof error !== 'object' || !('response' in error)) {
+    return undefined;
+  }
+  const response = error.response;
+  if (!response || typeof response !== 'object' || !('status' in response)) {
+    return undefined;
+  }
+  return typeof response.status === 'number' ? response.status : undefined;
+}
+
 export function FeedCardPreview({ item }: FeedCardPreviewProps) {
   const colorScheme = useColorScheme();
+  const isVideo = item.type === 'videos';
   const typeKey =
     item.type === 'answers'
       ? 'answer'
@@ -33,7 +45,12 @@ export function FeedCardPreview({ item }: FeedCardPreviewProps) {
           : 'question';
   const inlineContent = item.content as unknown;
   const hasInlineContent = hasInlineRichContent(inlineContent);
-  const queryKey = getRichContentQueryKey(item.type, item.id);
+  const queryKey = isVideo
+    ? ['video-preview', item.id]
+    : getRichContentQueryKey(
+        item.type as Exclude<typeof item.type, 'videos'>,
+        item.id,
+      );
 
   const { data: fullData, isLoading } = useQuery({
     queryKey,
@@ -52,14 +69,14 @@ export function FeedCardPreview({ item }: FeedCardPreviewProps) {
           return await getQuestion(item.id);
         }
         return null;
-      } catch (err: any) {
-        if (err.response?.status === 404) {
+      } catch (error: unknown) {
+        if (getResponseStatus(error) === 404) {
           return null;
         }
-        throw err;
+        throw error;
       }
     },
-    enabled: !hasInlineContent,
+    enabled: !isVideo && !hasInlineContent,
     placeholderData: hasInlineContent ? { content: inlineContent } : undefined,
     staleTime: RICH_CONTENT_STALE_TIME,
     retry: false,
@@ -110,7 +127,11 @@ export function FeedCardPreview({ item }: FeedCardPreviewProps) {
         style={styles.scrollContainer}
         showsVerticalScrollIndicator={true}
       >
-        {isLoading ? (
+        {isVideo ? (
+          <Text type="secondary" className="leading-6">
+            {item.excerpt || '点击卡片打开视频'}
+          </Text>
+        ) : isLoading ? (
           <View className="py-10 justify-center items-center bg-transparent">
             <ActivityIndicator size="small" color="#0084ff" />
             <Text className="mt-2 text-xs opacity-60">正在获取完整内容...</Text>

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -74,7 +74,7 @@ export const LikeButton = ({
             ? 'up'
             : 'neutral';
 
-      await voteContent(id, type, voteType as any);
+      await voteContent(id, type, voteType);
 
       setVoted(nextVoted);
       // count 可能是占位符（如 '-'），仅在数字时增减并通知外部
@@ -84,8 +84,8 @@ export const LikeButton = ({
         onVoteChange?.(nextVoted, newCount);
       }
       showToast(isUpvoted ? '已取消赞同' : '已赞同');
-    } catch (err) {
-      console.error('投票失败:', err);
+    } catch {
+      console.error('投票失败');
       showToast('操作失败，请稍后重试');
     } finally {
       setLoading(false);

--- a/components/QueryErrorView.tsx
+++ b/components/QueryErrorView.tsx
@@ -1,0 +1,40 @@
+import { Ionicons } from '@expo/vector-icons';
+import { Pressable } from 'react-native';
+import { Text, useThemeColor, View } from '@/components/Themed';
+
+interface QueryErrorViewProps {
+  message?: string;
+  onRetry: () => void;
+  compact?: boolean;
+}
+
+export function QueryErrorView({
+  message = '加载失败，请检查网络后重试',
+  onRetry,
+  compact = false,
+}: QueryErrorViewProps) {
+  const primaryColor = useThemeColor({}, 'primary');
+
+  return (
+    <View
+      className={`items-center justify-center bg-transparent ${compact ? 'px-4 py-5' : 'px-8 py-16'}`}
+    >
+      <Ionicons
+        name="cloud-offline-outline"
+        size={compact ? 26 : 40}
+        color="#999"
+      />
+      <Text type="secondary" className="text-center mt-2 text-sm">
+        {message}
+      </Text>
+      <Pressable
+        accessibilityRole="button"
+        className="mt-3 px-5 py-2 rounded-full"
+        style={{ backgroundColor: primaryColor }}
+        onPress={onRetry}
+      >
+        <Text className="text-white font-bold text-sm">重新加载</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/components/ShareMenu.tsx
+++ b/components/ShareMenu.tsx
@@ -9,16 +9,21 @@ import { MenuOption } from './MenuOption';
 import { Text, View } from './Themed';
 import { useColorScheme } from './useColorScheme';
 
-export type ShareContentType = 'answer' | 'question' | 'pin' | 'article';
+export type ShareContentType =
+  | 'answer'
+  | 'question'
+  | 'pin'
+  | 'article'
+  | 'video';
 
 interface ShareData {
   id: string | number;
-  title?: any;
+  title?: string;
   author?: string;
   authorHeadline?: string;
   content?: string;
   url?: string;
-  excerpt?: any;
+  excerpt?: string;
 }
 
 interface ShareMenuProps {
@@ -54,6 +59,8 @@ export function ShareMenu({ visible, onClose, type, data }: ShareMenuProps) {
         return `https://www.zhihu.com/pin/${data.id}`;
       case 'article':
         return `https://zhuanlan.zhihu.com/p/${data.id}`;
+      case 'video':
+        return `https://www.zhihu.com/zvideo/${data.id}`;
       default:
         return '';
     }
@@ -101,6 +108,9 @@ export function ShareMenu({ visible, onClose, type, data }: ShareMenuProps) {
         break;
       case 'article':
         text = `### ${title}\n**${author}**${headline} 的文章\n\n${link}`;
+        break;
+      case 'video':
+        text = `### ${title}\n**${author}**${headline} 的视频\n\n${link}`;
         break;
     }
 

--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -1,14 +1,30 @@
+import { type QueryKey, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ActivityIndicator, Image, Pressable } from 'react-native';
-import { followMember, unfollowMember } from '@/api/zhihu';
+import {
+  followMember,
+  unfollowMember,
+  type ZhihuMember,
+  type ZhihuMemberListItem,
+} from '@/api/zhihu';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
+import { useAuthStore } from '@/store/useAuthStore';
 import type { ZhihuBadge } from '@/types/zhihu';
+import { showToast } from '@/utils/toast';
 import { Text, useThemeColor, View } from './Themed';
-export const UserCard = ({ user }: { user: any }) => {
+
+interface UserCardProps {
+  user: ZhihuMemberListItem;
+  invalidateQueryKeys?: readonly QueryKey[];
+}
+
+export const UserCard = ({ user, invalidateQueryKeys = [] }: UserCardProps) => {
   const router = useRouter();
-  const [isFollowing, setIsFollowing] = useState(user.is_following);
+  const queryClient = useQueryClient();
+  const cookies = useAuthStore((state) => state.cookies);
+  const [isFollowing, setIsFollowing] = useState(Boolean(user.is_following));
   const [followerCount, setFollowerCount] = useState(user.follower_count || 0);
   const [loading, setLoading] = useState(false);
   const colorScheme = useColorScheme();
@@ -19,24 +35,58 @@ export const UserCard = ({ user }: { user: any }) => {
   const textSecondaryColor = Colors[colorScheme].textSecondary;
   const bgColor = Colors[colorScheme].background;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: FlashList recycles the component; identity changes must reset derived state even when the visible counts happen to match.
+  useEffect(() => {
+    setIsFollowing(Boolean(user.is_following));
+    setFollowerCount(user.follower_count || 0);
+  }, [user.follower_count, user.id, user.is_following, user.url_token]);
+
   const handleFollow = async () => {
     if (loading) return;
+    if (!cookies) {
+      router.push('/login');
+      return;
+    }
     const targetId = user.url_token || user.id;
     setLoading(true);
     try {
+      const nextIsFollowing = !isFollowing;
+      let nextFollowerCount = followerCount;
       if (isFollowing) {
         const data = await unfollowMember(targetId);
-        setIsFollowing(false);
-        if (data.follower_count !== undefined)
-          setFollowerCount(data.follower_count);
+        nextFollowerCount =
+          data.follower_count ?? Math.max(0, followerCount - 1);
       } else {
         const data = await followMember(targetId);
-        setIsFollowing(true);
-        if (data.follower_count !== undefined)
-          setFollowerCount(data.follower_count);
+        nextFollowerCount = data.follower_count ?? followerCount + 1;
       }
-    } catch (err) {
-      console.error('关注操作失败:', err);
+      setFollowerCount(nextFollowerCount);
+      setIsFollowing(nextIsFollowing);
+
+      const memberIdentifiers = Array.from(
+        new Set([String(user.id), user.url_token].filter(Boolean)),
+      );
+      for (const identifier of memberIdentifiers) {
+        queryClient.setQueryData<ZhihuMember>(
+          ['user-detail', identifier],
+          (currentMember) =>
+            currentMember
+              ? {
+                  ...currentMember,
+                  is_following: nextIsFollowing,
+                  follower_count: nextFollowerCount,
+                }
+              : currentMember,
+        );
+      }
+      await Promise.all(
+        invalidateQueryKeys.map((queryKey) =>
+          queryClient.invalidateQueries({ queryKey, exact: true }),
+        ),
+      );
+    } catch {
+      console.error('关注操作失败');
+      showToast('操作失败，请稍后重试');
     } finally {
       setLoading(false);
     }
@@ -78,7 +128,13 @@ export const UserCard = ({ user }: { user: any }) => {
         </View>
       </View>
       <Pressable
-        onPress={handleFollow}
+        accessibilityRole="button"
+        accessibilityState={{ busy: loading, selected: isFollowing }}
+        disabled={loading}
+        onPress={(event) => {
+          event.stopPropagation();
+          void handleFollow();
+        }}
         className="px-4 py-1.5 rounded-2xl justify-center items-center"
         style={
           isFollowing

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "analyze:rich-content": "node features/rich-content/tools/analyze-fixtures.mjs",
     "analyze:rich-content:inbox": "node features/rich-content/tools/analyze-fixtures.mjs --inbox",
     "test:rich-content": "node --test features/rich-content/tests/*.test.mjs",
+    "test:user-profile": "node --experimental-strip-types --test tests/userProfile.test.mjs",
     "postinstall": "patch-package",
     "format": "biome format . --write",
     "lint": "biome check . --write"

--- a/store/useAuthStore.ts
+++ b/store/useAuthStore.ts
@@ -1,22 +1,32 @@
 import * as FileSystem from 'expo-file-system/legacy';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
+import type { ZhihuMeInfo } from '@/api/zhihu/me';
 import { clearLocalAccountData } from '@/storage/localAccountData';
 import { resolveLocalAccountKey } from '@/utils/localAccount';
 
 // 适配器：使用 Expo FileSystem 代替 SecureStore 存储大数据
 // Android SecureStore 有 2048 字节的硬限制，存储多个账号信息时极易导致崩溃
 const AUTH_STORAGE_PATH = `${FileSystem.documentDirectory}auth-storage.json`;
+let authStorageExistedOnFirstRead: boolean | undefined;
+
+/** Only a missing auth file is eligible for the one-time legacy cookie import. */
+export function shouldImportLegacySession() {
+  return authStorageExistedOnFirstRead === false;
+}
 
 const fileStorage = {
   getItem: async (_name: string) => {
     try {
       const info = await FileSystem.getInfoAsync(AUTH_STORAGE_PATH);
+      authStorageExistedOnFirstRead ??= info.exists;
       if (info.exists) {
         return await FileSystem.readAsStringAsync(AUTH_STORAGE_PATH);
       }
       return null;
     } catch (e) {
+      // A read failure must not make an old native cookie authoritative.
+      authStorageExistedOnFirstRead ??= true;
       console.error('读取存储失败:', e);
       return null;
     }
@@ -24,6 +34,7 @@ const fileStorage = {
   setItem: async (_name: string, value: string) => {
     try {
       await FileSystem.writeAsStringAsync(AUTH_STORAGE_PATH, value);
+      authStorageExistedOnFirstRead = true;
     } catch (e) {
       console.error('写入存储失败:', e);
     }
@@ -39,7 +50,7 @@ const fileStorage = {
 
 export interface Account {
   cookies: string;
-  me: any;
+  me: ZhihuMeInfo;
   last_updated?: number; // 添加更新时间戳
 }
 
@@ -57,13 +68,26 @@ interface AuthState {
   accounts: Account[];
   activeAccountIndex: number;
   cookies: string | null;
-  me: any | null; // 存储个人详细信息
+  me: ZhihuMeInfo | null; // 存储个人详细信息
   setCookies: (cookies: string) => void;
-  setMe: (me: any) => void;
-  addAccount: (cookies: string, me: any) => void;
+  setMe: (me: ZhihuMeInfo) => void;
+  addAccount: (cookies: string, me: ZhihuMeInfo) => void;
   switchAccount: (index: number) => void;
   removeAccount: (index: number) => void;
   logout: () => void;
+}
+
+interface PersistedAuthState {
+  accounts?: Account[];
+  activeAccountIndex?: number;
+  cookies?: string | null;
+  me?: ZhihuMeInfo | null;
+}
+
+function normalizePersistedAuthState(value: unknown): PersistedAuthState {
+  return value && typeof value === 'object'
+    ? (value as PersistedAuthState)
+    : {};
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -193,9 +217,9 @@ export const useAuthStore = create<AuthState>()(
       name: 'auth-storage',
       storage: createJSONStorage(() => fileStorage),
       version: 2, // 升级版本以支持 last_updated 结构（虽然是可选的）
-      migrate: (persistedState: any, version: number) => {
+      migrate: (persistedState: unknown, version: number) => {
+        const state = normalizePersistedAuthState(persistedState);
         if (version === 0) {
-          const state = persistedState as any;
           if (state.cookies && state.me) {
             return {
               ...state,
@@ -211,9 +235,9 @@ export const useAuthStore = create<AuthState>()(
         }
         if (version === 1) {
           // v1 -> v2: 主要是增加了 last_updated，现有数据继续使用即可
-          return persistedState;
+          return state as AuthState;
         }
-        return persistedState;
+        return state as AuthState;
       },
     },
   ),

--- a/tests/userProfile.test.mjs
+++ b/tests/userProfile.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseZhihuUrl } from '../utils/url.ts';
+import {
+  getNextPageOffset,
+  isOwnMemberProfile,
+  isSameMember,
+  normalizeUserFeedType,
+} from '../utils/userProfile.ts';
+
+test('matches a member by immutable id or url token', () => {
+  const member = { id: 'hash-id', url_token: 'friendly-token' };
+
+  assert.equal(isSameMember('hash-id', member), true);
+  assert.equal(isSameMember('friendly-token', member), true);
+  assert.equal(isSameMember('another-user', member), false);
+});
+
+test('does not treat every loaded profile as the signed-in member', () => {
+  const me = { id: 'my-hash-id', url_token: 'my-token' };
+  const anotherUser = {
+    id: 'another-hash-id',
+    url_token: 'another-token',
+  };
+
+  assert.equal(isOwnMemberProfile('another-token', me, anotherUser), false);
+  assert.equal(isOwnMemberProfile('my-token', me, me), true);
+  assert.equal(
+    isOwnMemberProfile(
+      'my-token',
+      { id: 'my-hash-id' },
+      { id: 'my-hash-id', url_token: 'my-token' },
+    ),
+    true,
+  );
+});
+
+test('normalizes profile content types without treating videos as answers', () => {
+  assert.equal(normalizeUserFeedType('answer'), 'answers');
+  assert.equal(normalizeUserFeedType('articles'), 'articles');
+  assert.equal(normalizeUserFeedType('zvideo'), 'videos');
+  assert.equal(normalizeUserFeedType('videos'), 'videos');
+  assert.equal(normalizeUserFeedType('unsupported'), null);
+});
+
+test('reads pagination offsets through URLSearchParams', () => {
+  assert.equal(
+    getNextPageOffset(
+      'https://www.zhihu.com/api/v4/members/demo/answers?limit=20&offset=40',
+    ),
+    40,
+  );
+  assert.equal(
+    getNextPageOffset('/api/v4/items?offset=not-a-number'),
+    undefined,
+  );
+  assert.equal(getNextPageOffset(undefined), undefined);
+});
+
+test('normalizes public Zhihu video links to the internal video route', () => {
+  assert.equal(
+    parseZhihuUrl('https://www.zhihu.com/zvideo/123456789'),
+    '/video/123456789',
+  );
+  assert.equal(
+    parseZhihuUrl('https://oia.zhihu.com/zvideos/987654321'),
+    '/video/987654321',
+  );
+});

--- a/utils/authSession.ts
+++ b/utils/authSession.ts
@@ -1,0 +1,52 @@
+import CookieManager from '@react-native-cookies/cookies';
+import * as SecureStore from 'expo-secure-store';
+
+export const LEGACY_COOKIE_STORAGE_KEY = 'user_cookies';
+const SECURE_STORE_SAFE_COOKIE_LENGTH = 2000;
+
+function parseCookieString(cookieString: string) {
+  return cookieString
+    .split(';')
+    .map((pair) => pair.trim())
+    .filter(Boolean)
+    .flatMap((pair) => {
+      const separatorIndex = pair.indexOf('=');
+      if (separatorIndex <= 0) return [];
+      const name = pair.slice(0, separatorIndex);
+      const value = pair.slice(separatorIndex + 1);
+      return name && value ? [{ name, value }] : [];
+    });
+}
+
+/**
+ * Keep the native cookie jar and the legacy SecureStore backup aligned.
+ * The Zustand file store remains the source of truth for active-account state.
+ */
+export async function syncNativeSessionCookies(cookieString: string | null) {
+  await CookieManager.clearAll(true);
+
+  if (!cookieString) {
+    await SecureStore.deleteItemAsync(LEGACY_COOKIE_STORAGE_KEY);
+    return;
+  }
+
+  for (const cookie of parseCookieString(cookieString)) {
+    await CookieManager.set(
+      'https://www.zhihu.com',
+      {
+        ...cookie,
+        domain: '.zhihu.com',
+        path: '/',
+        secure: true,
+      },
+      true,
+    );
+  }
+
+  if (cookieString.length < SECURE_STORE_SAFE_COOKIE_LENGTH) {
+    await SecureStore.setItemAsync(LEGACY_COOKIE_STORAGE_KEY, cookieString);
+  } else {
+    // Never leave a previous account's short cookie as a fallback.
+    await SecureStore.deleteItemAsync(LEGACY_COOKIE_STORAGE_KEY);
+  }
+}

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -74,6 +74,10 @@ function normalizeSupportedPath(path: string): string | null {
       buildPath: (match) => `/pin/${match[1]}`,
     },
     {
+      pattern: /^\/(?:zvideos?|videos?)\/(\d+)$/,
+      buildPath: (match) => `/video/${match[1]}`,
+    },
+    {
       pattern:
         /^\/(?:people|users?)\/([^/]+)(?:\/(followers|following|mutual|stream))?$/,
       buildPath: (match) =>

--- a/utils/userProfile.ts
+++ b/utils/userProfile.ts
@@ -1,0 +1,100 @@
+export interface MemberIdentity {
+  id?: string | number | null;
+  url_token?: string | null;
+}
+
+export type UserFeedType =
+  | 'answers'
+  | 'articles'
+  | 'questions'
+  | 'pins'
+  | 'videos';
+
+function normalizeIdentity(value: string | number | null | undefined) {
+  return value === null || value === undefined ? null : String(value);
+}
+
+/** Match a route token against every stable identifier returned for a member. */
+export function isSameMember(
+  routeId: string | number | null | undefined,
+  ...members: Array<MemberIdentity | null | undefined>
+) {
+  const normalizedRouteId = normalizeIdentity(routeId);
+  if (!normalizedRouteId) return false;
+
+  return members.some((member) => {
+    if (!member) return false;
+    return [member.id, member.url_token].some(
+      (candidate) => normalizeIdentity(candidate) === normalizedRouteId,
+    );
+  });
+}
+
+/**
+ * Decide whether a profile belongs to the signed-in member.
+ *
+ * The route will naturally match the loaded profile, so the profile itself must
+ * never be used as independent proof that it is the current member. It is only
+ * useful for bridging an id/url_token mismatch with the current-member payload.
+ */
+export function isOwnMemberProfile(
+  routeId: string | number | null | undefined,
+  currentMember: MemberIdentity | null | undefined,
+  profileMember: MemberIdentity | null | undefined,
+) {
+  if (!currentMember) return false;
+  if (isSameMember(routeId, currentMember)) return true;
+  if (!profileMember) return false;
+
+  const currentIdentifiers = [currentMember.id, currentMember.url_token]
+    .map(normalizeIdentity)
+    .filter((value): value is string => Boolean(value));
+  const profileIdentifiers = new Set(
+    [profileMember.id, profileMember.url_token]
+      .map(normalizeIdentity)
+      .filter((value): value is string => Boolean(value)),
+  );
+
+  return currentIdentifiers.some((identifier) =>
+    profileIdentifiers.has(identifier),
+  );
+}
+
+export function normalizeUserFeedType(
+  type: string | null | undefined,
+): UserFeedType | null {
+  switch (type) {
+    case 'answer':
+    case 'answers':
+      return 'answers';
+    case 'article':
+    case 'articles':
+      return 'articles';
+    case 'question':
+    case 'questions':
+      return 'questions';
+    case 'pin':
+    case 'pins':
+      return 'pins';
+    case 'video':
+    case 'videos':
+    case 'zvideo':
+    case 'zvideos':
+      return 'videos';
+    default:
+      return null;
+  }
+}
+
+export function getNextPageOffset(nextUrl: string | null | undefined) {
+  if (!nextUrl) return undefined;
+  try {
+    const url = new URL(nextUrl, 'https://www.zhihu.com');
+    const offset = url.searchParams.get('offset');
+    if (offset === null) return undefined;
+    const parsedOffset = Number.parseInt(offset, 10);
+    return Number.isFinite(parsedOffset) ? parsedOffset : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## 概要

- 修正本人/他人主页识别，恢复他人主页的关注与取关按钮，并增加回归测试
- 修复个人页刷新、错误状态、统计入口、Tab 激活刷新与账号切换流程
- 修复关注列表卡片复用导致的状态错位，并精确同步用户详情和关注列表缓存
- 修复用户内容搜索刷新、分页、错误吞噬、稳定 key 与视频类型误判
- 新增视频详情路由、分享链接及 Android 外部视频链接 Intent Filter
- 加固登录态恢复与 Cookie 同步，避免游客态误用旧账号 Cookie，并保留首次安装迁移
- 收紧相关 API、页面和共享组件的 TypeScript 类型，移除敏感错误对象日志

## 验证

- `./node_modules/.bin/tsc --noEmit`
- 改动的 29 个文件通过 `biome check`
- `npm run test:user-profile`：5/5 通过
- `npm run test:rich-content`：15/15 通过
- `npm run analyze:rich-content`：全部 fixture 校验正常
- `git diff --check`


### Biome 全仓变化

| 指标 | 修复前基线 | 当前分支 | 减少 |
| --- | ---: | ---: | ---: |
| Errors | 23 | 21 | 2 |
| Warnings | 322 | 196 | 126 |
| 合计 | 345 | 217 | 128（约 37%） |

本次 PR 涉及的 29 个文件均为 **0 error / 0 warning**。全仓仍有 21 个 error 和 196 个 warning，均为其他文件中的存量诊断。

## 备注

- 尚未执行 iOS/Android 真机交互验证
- Android 新增的视频链接 Intent Filter 需要下一次原生重新构建后生效