### PR TITLE
fix(comments): confirm copy from action sheet

### DIFF
--- a/app/comments/[id].tsx
+++ b/app/comments/[id].tsx
@@ -33,14 +33,13 @@ import {
   getQuestionCommentsV5 as getQuestionComments,
 } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
+import { CommentActionSheet } from '@/components/CommentActionSheet';
 import { CommentContent } from '@/components/CommentContent';
 import { LikeButton } from '@/components/LikeButton';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
-import { copyToClipboard } from '@/utils/clipboard';
 import { formatDate } from '@/utils/date';
-import { showToast } from '@/utils/toast';
 
 export default function CommentScreen() {
   const { id, type, segmentId, count, text } = useLocalSearchParams<{
@@ -55,6 +54,10 @@ export default function CommentScreen() {
   const [replyTo, setReplyTo] = useState<{ id: string; name: string } | null>(
     null,
   );
+  const [commentAction, setCommentAction] = useState<{
+    htmlContent: string;
+    authorName: string;
+  } | null>(null);
   const inputRef = React.useRef<TextInput>(null);
   const _queryClient = useQueryClient();
   const _insets = useSafeAreaInsets();
@@ -161,30 +164,13 @@ export default function CommentScreen() {
     if (urlToken) router.push(`/user/${urlToken}`);
   };
 
-  // 提取 HTML 评论的纯文本（用于长按复制）
-  const extractPlainText = (html: string) => {
-    const imageRegex =
-      /<a[^>]+class="comment_img"[^>]*href="([^"]+)"[^>]*>.*?<\/a>|<a[^>]+href="([^"]+)"[^>]*class="comment_img"[^>]*>.*?<\/a>/gi;
-    return html
-      .replace(imageRegex, '[\u56fe\u7247]')
-      .replace(/<[^>]+>/g, '')
-      .trim();
-  };
-
-  const handleLongPressComment = async (html: string, authorName: string) => {
-    const text = extractPlainText(html);
-    if (!text) return;
-    const ok = await copyToClipboard(text);
-    if (ok) showToast(`已复制 @${authorName} 的评论`);
+  const handleLongPressComment = (htmlContent: string, authorName: string) => {
+    setCommentAction({ htmlContent, authorName });
   };
 
   const renderComment = ({ item }: { item: CommentItem }) => {
     return (
-      <BouncyButton
-        onLongPress={() =>
-          handleLongPressComment(item.content, item.author.member.name)
-        }
-        delayLongPress={400}
+      <View
         style={{
           paddingHorizontal: 15,
           paddingVertical: 13,
@@ -217,9 +203,15 @@ export default function CommentScreen() {
                 {item.author.member.name}
               </Text>
             </BouncyButton>
-            <View className="mt-2 bg-transparent">
+            <BouncyButton
+              onLongPress={() =>
+                handleLongPressComment(item.content, item.author.member.name)
+              }
+              delayLongPress={400}
+              style={{ marginTop: 8, borderRadius: 4 }}
+            >
               <CommentContent htmlContent={item.content} width={contentWidth} />
-            </View>
+            </BouncyButton>
 
             <View className="flex-row justify-between items-center bg-transparent">
               <Text
@@ -310,7 +302,7 @@ export default function CommentScreen() {
             )}
           </View>
         </View>
-      </BouncyButton>
+      </View>
     );
   };
 
@@ -520,6 +512,13 @@ export default function CommentScreen() {
           </View>
         </BlurView>
       </Animated.View>
+
+      <CommentActionSheet
+        visible={commentAction !== null}
+        htmlContent={commentAction?.htmlContent ?? null}
+        authorName={commentAction?.authorName ?? null}
+        onClose={() => setCommentAction(null)}
+      />
     </View>
   );
 }

--- a/app/comments/replies/[id].tsx
+++ b/app/comments/replies/[id].tsx
@@ -28,14 +28,13 @@ import {
   getComment,
 } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
+import { CommentActionSheet } from '@/components/CommentActionSheet';
 import { CommentContent } from '@/components/CommentContent';
 import { LikeButton } from '@/components/LikeButton';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
-import { copyToClipboard } from '@/utils/clipboard';
 import { formatDate } from '@/utils/date';
-import { showToast } from '@/utils/toast';
 
 export default function ReplyDetailScreen() {
   const { id, parent } = useLocalSearchParams<{
@@ -46,6 +45,10 @@ export default function ReplyDetailScreen() {
   const [replyTo, setReplyTo] = useState<{ id: string; name: string } | null>(
     null,
   );
+  const [commentAction, setCommentAction] = useState<{
+    htmlContent: string;
+    authorName: string;
+  } | null>(null);
   const inputRef = useRef<TextInput>(null);
   const router = useRouter();
   const _queryClient = useQueryClient();
@@ -159,30 +162,13 @@ export default function ReplyDetailScreen() {
     if (urlToken) router.push(`/user/${urlToken}`);
   };
 
-  // 提取 HTML 评论的纯文本（用于长按复制）
-  const extractPlainText = (html: string) => {
-    const imageRegex =
-      /<a[^>]+class="comment_img"[^>]*href="([^"]+)"[^>]*>.*?<\/a>|<a[^>]+href="([^"]+)"[^>]*class="comment_img"[^>]*>.*?<\/a>/gi;
-    return html
-      .replace(imageRegex, '[\u56fe\u7247]')
-      .replace(/<[^>]+>/g, '')
-      .trim();
-  };
-
-  const handleLongPressComment = async (html: string, authorName: string) => {
-    const text = extractPlainText(html);
-    if (!text) return;
-    const ok = await copyToClipboard(text);
-    if (ok) showToast(`已复制 @${authorName} 的评论`);
+  const handleLongPressComment = (htmlContent: string, authorName: string) => {
+    setCommentAction({ htmlContent, authorName });
   };
 
   const renderReply = ({ item }: { item: CommentItem }) => {
     return (
-      <BouncyButton
-        onLongPress={() =>
-          handleLongPressComment(item.content, item.author.member.name)
-        }
-        delayLongPress={400}
+      <View
         style={{
           borderBottomWidth: StyleSheet.hairlineWidth,
           borderBottomColor: borderColor,
@@ -230,9 +216,15 @@ export default function ReplyDetailScreen() {
                 </Text>
               )}
             </Text>
-            <View className="mt-1 bg-transparent">
+            <BouncyButton
+              onLongPress={() =>
+                handleLongPressComment(item.content, item.author.member.name)
+              }
+              delayLongPress={400}
+              style={{ marginTop: 4, borderRadius: 4 }}
+            >
               <CommentContent htmlContent={item.content} width={contentWidth} />
-            </View>
+            </BouncyButton>
 
             <View className="flex-row justify-between items-center bg-transparent">
               <Text
@@ -275,7 +267,7 @@ export default function ReplyDetailScreen() {
             </View>
           </View>
         </View>
-      </BouncyButton>
+      </View>
     );
   };
 
@@ -317,12 +309,21 @@ export default function ReplyDetailScreen() {
                 {parentComment.author.member.name}
               </Text>
             </View>
-            <View className="mt-1 bg-transparent">
+            <BouncyButton
+              onLongPress={() =>
+                handleLongPressComment(
+                  parentComment.content,
+                  parentComment.author.member.name,
+                )
+              }
+              delayLongPress={400}
+              style={{ marginTop: 4, borderRadius: 4 }}
+            >
               <CommentContent
                 htmlContent={parentComment.content}
                 width={contentWidth}
               />
-            </View>
+            </BouncyButton>
 
             <View className="flex-row justify-between items-center bg-transparent">
               <Text
@@ -513,6 +514,13 @@ export default function ReplyDetailScreen() {
           </View>
         </BlurView>
       </Animated.View>
+
+      <CommentActionSheet
+        visible={commentAction !== null}
+        htmlContent={commentAction?.htmlContent ?? null}
+        authorName={commentAction?.authorName ?? null}
+        onClose={() => setCommentAction(null)}
+      />
     </View>
   );
 }

--- a/components/CommentActionSheet.tsx
+++ b/components/CommentActionSheet.tsx
@@ -1,0 +1,218 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useEffect, useRef } from 'react';
+import {
+  Animated,
+  Modal,
+  Pressable,
+  View as RNView,
+  StyleSheet,
+  TouchableWithoutFeedback,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Text, View } from '@/components/Themed';
+import { useColorScheme } from '@/components/useColorScheme';
+import Colors from '@/constants/Colors';
+import { copyToClipboard } from '@/utils/clipboard';
+import { ImpactFeedbackStyle, impactAsync } from '@/utils/haptics';
+import { showToast } from '@/utils/toast';
+
+interface CommentActionSheetProps {
+  visible: boolean;
+  htmlContent: string | null;
+  authorName: string | null;
+  onClose: () => void;
+}
+
+function extractCommentText(htmlContent: string): string {
+  const imageRegex =
+    /<a[^>]+class="comment_img"[^>]*href="([^"]+)"[^>]*>.*?<\/a>|<a[^>]+href="([^"]+)"[^>]*class="comment_img"[^>]*>.*?<\/a>/gi;
+
+  return htmlContent
+    .replace(imageRegex, '[图片]')
+    .replace(/<[^>]+>/g, '')
+    .trim();
+}
+
+export function CommentActionSheet({
+  visible,
+  htmlContent,
+  authorName,
+  onClose,
+}: CommentActionSheetProps) {
+  const colorScheme = useColorScheme();
+  const insets = useSafeAreaInsets();
+  const slideAnim = useRef(new Animated.Value(300)).current;
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const commentText = htmlContent ? extractCommentText(htmlContent) : '';
+
+  useEffect(() => {
+    if (visible) {
+      void impactAsync(ImpactFeedbackStyle.Medium);
+      Animated.parallel([
+        Animated.timing(fadeAnim, {
+          toValue: 1,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+        Animated.spring(slideAnim, {
+          toValue: 0,
+          damping: 25,
+          stiffness: 250,
+          useNativeDriver: true,
+        }),
+      ]).start();
+      return;
+    }
+
+    Animated.parallel([
+      Animated.timing(fadeAnim, {
+        toValue: 0,
+        duration: 150,
+        useNativeDriver: true,
+      }),
+      Animated.timing(slideAnim, {
+        toValue: 300,
+        duration: 180,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [fadeAnim, slideAnim, visible]);
+
+  if (!visible || !htmlContent || !authorName || !commentText) return null;
+
+  const cardBackground = Colors[colorScheme].surface;
+  const itemBackground = Colors[colorScheme].backgroundTertiary;
+  const textColor = Colors[colorScheme].text;
+
+  const handleCopy = async () => {
+    onClose();
+    const copied = await copyToClipboard(commentText);
+    if (copied) showToast(`已复制 @${authorName} 的评论`);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <View className="flex-1 justify-end bg-transparent">
+        <TouchableWithoutFeedback onPress={onClose}>
+          <Animated.View
+            style={[
+              StyleSheet.absoluteFillObject,
+              {
+                backgroundColor: Colors[colorScheme].blackTransparent,
+                opacity: fadeAnim,
+              },
+            ]}
+          />
+        </TouchableWithoutFeedback>
+
+        <Animated.View
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: cardBackground,
+              paddingBottom: Math.max(insets.bottom, 16) + 8,
+              transform: [{ translateY: slideAnim }],
+            },
+          ]}
+        >
+          <RNView className="items-center pt-2 pb-1">
+            <RNView
+              style={{
+                width: 36,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: colorScheme === 'dark' ? '#48484A' : '#D1D1D6',
+              }}
+            />
+          </RNView>
+
+          <RNView className="flex-row items-center px-4 py-3">
+            <RNView className="flex-1 pr-3">
+              <Text
+                className="text-base font-bold"
+                style={{ color: textColor }}
+              >
+                @{authorName} 的评论
+              </Text>
+              <Text type="secondary" className="text-sm mt-1" numberOfLines={3}>
+                {commentText}
+              </Text>
+            </RNView>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="关闭评论操作"
+              onPress={onClose}
+              className="p-2 rounded-full"
+              style={{ backgroundColor: itemBackground }}
+              hitSlop={8}
+            >
+              <Ionicons
+                name="close"
+                size={18}
+                color={Colors[colorScheme].textSecondary}
+              />
+            </Pressable>
+          </RNView>
+
+          <RNView className="px-4 pt-2">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="复制评论"
+              onPress={() => void handleCopy()}
+              className="flex-row items-center p-3.5 rounded-2xl"
+              style={{ backgroundColor: itemBackground }}
+            >
+              <RNView
+                className="w-9 h-9 rounded-xl justify-center items-center mr-3"
+                style={{ backgroundColor: `${Colors[colorScheme].primary}1A` }}
+              >
+                <Ionicons
+                  name="copy-outline"
+                  size={20}
+                  color={Colors[colorScheme].primary}
+                />
+              </RNView>
+              <Text
+                className="text-base font-semibold"
+                style={{ color: textColor }}
+              >
+                复制评论
+              </Text>
+            </Pressable>
+          </RNView>
+
+          <RNView className="px-4 mt-3">
+            <Pressable
+              accessibilityRole="button"
+              onPress={onClose}
+              className="py-3.5 items-center rounded-2xl"
+              style={{ backgroundColor: itemBackground }}
+            >
+              <Text type="secondary" className="text-base font-semibold">
+                取消
+              </Text>
+            </Pressable>
+          </RNView>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  sheet: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: -4 },
+    shadowOpacity: 0.1,
+    shadowRadius: 12,
+    elevation: 16,
+  },
+});


### PR DESCRIPTION
## Summary

- replace immediate long-press clipboard writes with a confirmation action sheet
- show the selected comment author and a short content preview before copying
- limit the long-press target to comment content to reduce scroll-time activations and avoid nested reply previews triggering the parent comment
- apply the behavior consistently to comment lists, reply lists, and the parent comment in reply details

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `npm run test:rich-content` (15/15 passed)
- `./node_modules/.bin/biome check components/CommentActionSheet.tsx app/comments/[id].tsx app/comments/replies/[id].tsx`
- `git diff --check`

Resolves #48