### PR TITLE
feat(comments): support image upload and comment actions

### DIFF
--- a/api/zhihu/comment.ts
+++ b/api/zhihu/comment.ts
@@ -1,4 +1,5 @@
 import apiClient from '../client';
+import type { ZhihuVoteResponse } from './voters';
 
 export interface CommentVipIcon {
   url?: string;
@@ -7,12 +8,28 @@ export interface CommentVipIcon {
 
 export interface CommentVipInfo {
   is_vip: boolean;
+  target_url?: string | null;
   vip_icon?: CommentVipIcon;
 }
 
 export interface CommentBadge {
   type: string;
   description: string;
+}
+
+export interface CommentBadgeV2 {
+  title: string;
+  merged_badges: unknown[] | null;
+  detail_badges: unknown[] | null;
+}
+
+export interface CommentExposedMedal {
+  medal_id: string;
+  medal_name: string;
+  avatar_url: string;
+  description: string;
+  medal_avatar_frame: string;
+  can_click: boolean;
 }
 
 export interface CommentMember {
@@ -27,9 +44,15 @@ export interface CommentMember {
   user_type?: string;
   headline?: string;
   badge?: CommentBadge[];
+  badge_v2?: CommentBadgeV2;
+  exposed_medal?: CommentExposedMedal;
   gender?: number;
   is_advertiser?: boolean;
   vip_info?: CommentVipInfo;
+  kvip_info?: CommentVipInfo;
+  level_info?: unknown | null;
+  is_anonymous?: boolean;
+  ring_info?: unknown | null;
 }
 
 export interface CommentAuthor {
@@ -43,22 +66,47 @@ export interface CommentTag {
   color?: string;
   night_color?: string;
   has_border?: boolean;
+  border_color?: string;
+  border_night_color?: string;
 }
 
 export interface CommentItem {
   id: number | string;
   type: 'comment';
+  resource_type?: string;
+  member_id?: number | string;
   url?: string;
   content: string;
+  score?: number;
+  comment_type?: number;
+  created_time: number;
+  is_delete?: boolean;
+  reviewing?: boolean;
+  reply_comment_id?: number | string | null;
+  reply_root_comment_id?: number | string | null;
+  liked?: boolean;
+  like_count?: number;
+  disliked?: boolean;
+  dislike_count?: number;
+  is_author?: boolean;
+  can_like?: boolean;
+  can_dislike?: boolean;
+  can_delete?: boolean;
+  can_reply?: boolean;
+  can_hot?: boolean;
+  can_author_top?: boolean;
+  is_author_top?: boolean;
+  can_share?: boolean;
+  can_unfold?: boolean;
+  can_truncate?: boolean;
+  can_more?: boolean;
   comment_tag?: CommentTag[];
+  author_tag?: CommentTag[];
+  reply_author_tag?: CommentTag[];
+  content_tag?: CommentTag[];
   featured?: boolean;
   top?: boolean;
   collapsed?: boolean;
-  is_author?: boolean;
-  is_delete?: boolean;
-  created_time: number;
-  resource_type?: string;
-  reviewing?: boolean;
   allow_like?: boolean;
   allow_delete?: boolean;
   allow_reply?: boolean;
@@ -67,24 +115,73 @@ export interface CommentItem {
   can_collapse?: boolean;
   attached_info?: string;
   author: CommentAuthor;
-  vote_count: number;
+  vote_count?: number;
   reply_to_author?: CommentAuthor | null;
   voting?: boolean;
-  liked?: boolean;
-  disliked?: boolean;
   censor_status?: number;
   address_text?: string;
   child_comment_count: number;
+  child_comment_next_offset?: string | number | null;
   child_comments: CommentItem[];
   relationship?: {
     voting: number;
   };
+  is_visible_only_to_myself?: boolean;
+  _?: unknown;
+  level_tag?: number;
+  is_gift?: boolean;
+  disclaimer_info?: unknown | null;
 }
 
 export interface CommentStatus {
-  can_comment: boolean;
-  can_reply: boolean;
+  type?: number;
+  text?: string;
+  induce_text?: string;
+  can_comment?: boolean;
+  can_reply?: boolean;
   toast?: string;
+}
+
+export interface CommentAtmosphereVotingDetail {
+  emoji_level: string;
+  title: string;
+  normal_icon: string;
+  selected_icon: string;
+}
+
+export interface CommentAtmosphereVotingConfig {
+  daily_frequency: number;
+  frequency_interval: number;
+  min_num_of_root_comment: number;
+  location: number;
+  title: string;
+  detail: CommentAtmosphereVotingDetail[];
+}
+
+export interface CommentCounts {
+  total_counts: number;
+  collapsed_counts: number;
+  reviewing_counts: number;
+  segment_comment_counts: number;
+}
+
+export interface CommentPermission {
+  permission: string;
+  text: string;
+  checked: boolean;
+  disable: boolean;
+  disable_alert: string;
+  icon: string;
+}
+
+export interface CommentEditStatus {
+  can_reply: boolean;
+  toast: string;
+}
+
+export interface CommentSorter {
+  type: string;
+  text: string;
 }
 
 export interface CommentPaging {
@@ -96,20 +193,45 @@ export interface CommentPaging {
 }
 
 export interface ZhihuCommentResponse {
+  ad_plugin_infos?: unknown[];
+  atmosphere_voting_config?: CommentAtmosphereVotingConfig;
   featured_counts?: number;
   common_counts?: number;
   collapsed_counts?: number;
   reviewing_counts?: number;
-  counts?: {
-    total_counts: number;
-  };
+  counts?: CommentCounts;
   comment_status?: CommentStatus;
+  current_permission?: CommentPermission;
+  edit_status?: CommentEditStatus;
+  header?: unknown[];
+  is_content_author?: boolean;
+  is_content_rewardable?: boolean;
   paging: CommentPaging;
   data: CommentItem[];
+  sorter?: CommentSorter[];
+}
+
+export interface DeleteCommentResponse {
+  success: boolean;
+}
+
+export type CommentResourceType = 'answers' | 'questions' | 'articles' | 'pins';
+
+export interface CreateCommentResponse {
+  id?: string | number;
+  type?: string;
+  content?: string;
+  [key: string]: unknown;
+}
+
+export interface CreateCommentPayload {
+  content: string;
+  type: 'comment';
+  reply_to_comment_id?: string | number;
 }
 
 export const getComment = async (id: string | number): Promise<CommentItem> => {
-  const res = await apiClient.get(`/comments/${id}`);
+  const res = await apiClient.get<CommentItem>(`/comments/${id}`);
   return normalizeComment(res.data);
 };
 
@@ -120,7 +242,7 @@ export const getAnswerComments = async (
 ): Promise<ZhihuCommentResponse> => {
   const include =
     'data[*].author,content,child_comment_count,child_comments,vote_count,created_time';
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuCommentResponse>(
     `/answers/${id}/root_comments?limit=${limit}&offset=${offset}&include=${include}`,
   );
   if (res.data?.data) {
@@ -132,11 +254,14 @@ export const getAnswerComments = async (
 export const createAnswerComment = async (
   id: string | number,
   content: string,
-): Promise<any> => {
-  const res = await apiClient.post(`/answers/${id}/comments`, {
-    content,
-    type: 'comment',
-  });
+): Promise<CreateCommentResponse> => {
+  const res = await apiClient.post<CreateCommentResponse>(
+    `/answers/${id}/comments`,
+    {
+      content,
+      type: 'comment',
+    },
+  );
   return res.data;
 };
 
@@ -147,7 +272,7 @@ export const getChildComments = async (
 ): Promise<ZhihuCommentResponse> => {
   const include =
     'data[*].author,vote_count,content,created_time,reply_to_author';
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuCommentResponse>(
     `/comments/${id}/child_comments?limit=${limit}&offset=${offset}&include=${include}`,
   );
   if (res.data?.data) {
@@ -163,7 +288,7 @@ export const getCommentReplies = async (
 ): Promise<ZhihuCommentResponse> => {
   const include =
     'data[*].author,content,vote_count,created_time,reply_to_comment';
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuCommentResponse>(
     `/comments/${id}/replies?limit=${limit}&offset=${offset}&include=${include}`,
   );
   if (res.data?.data) {
@@ -175,25 +300,32 @@ export const getCommentReplies = async (
 export const createCommentReply = async (
   id: string | number,
   content: string,
-  extra?: Record<string, any>,
-): Promise<any> => {
-  const res = await apiClient.post(`/comments/${id}/replies`, {
-    content,
-    type: 'comment',
-    ...extra,
-  });
+  extra?: Record<string, unknown>,
+): Promise<CreateCommentResponse> => {
+  const res = await apiClient.post<CreateCommentResponse>(
+    `/comments/${id}/replies`,
+    {
+      content,
+      type: 'comment',
+      ...extra,
+    },
+  );
   return res.data;
 };
 
 export const voteComment = async (
   id: string | number,
   type: 'up' | 'neutral',
-): Promise<any> => {
+): Promise<ZhihuVoteResponse> => {
   if (type === 'up') {
-    const res = await apiClient.post(`/comments/${id}/like`);
+    const res = await apiClient.post<ZhihuVoteResponse>(
+      `/comments/${encodeURIComponent(String(id))}/like`,
+    );
     return res.data;
   } else {
-    const res = await apiClient.delete(`/comments/${id}/like`);
+    const res = await apiClient.delete<ZhihuVoteResponse>(
+      `/comments/${encodeURIComponent(String(id))}/like`,
+    );
     return res.data;
   }
 };
@@ -205,7 +337,7 @@ export const getQuestionComments = async (
 ): Promise<ZhihuCommentResponse> => {
   const include =
     'data[*].author,content,child_comment_count,child_comments,vote_count,created_time';
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuCommentResponse>(
     `/questions/${id}/root_comments?limit=${limit}&offset=${offset}&include=${include}`,
   );
   if (res.data?.data) {
@@ -217,11 +349,14 @@ export const getQuestionComments = async (
 export const createQuestionComment = async (
   id: string | number,
   content: string,
-): Promise<any> => {
-  const res = await apiClient.post(`/questions/${id}/comments`, {
-    content,
-    type: 'comment',
-  });
+): Promise<CreateCommentResponse> => {
+  const res = await apiClient.post<CreateCommentResponse>(
+    `/questions/${id}/comments`,
+    {
+      content,
+      type: 'comment',
+    },
+  );
   return res.data;
 };
 
@@ -229,13 +364,34 @@ export const createQuestionComment = async (
  * Zhihu Comment V5 APIs
  */
 
+export const createCommentV5 = async (
+  resourceType: CommentResourceType,
+  resourceId: string | number,
+  content: string,
+  replyToCommentId?: string | number,
+): Promise<CreateCommentResponse> => {
+  const payload: CreateCommentPayload = {
+    content,
+    type: 'comment',
+  };
+  if (replyToCommentId !== undefined) {
+    payload.reply_to_comment_id = replyToCommentId;
+  }
+
+  const res = await apiClient.post<CreateCommentResponse>(
+    `/comment_v5/${resourceType}/${encodeURIComponent(String(resourceId))}/comment`,
+    payload,
+  );
+  return res.data;
+};
+
 export const getAnswerCommentsV5 = async (
   id: string | number,
   limit = 20,
   offset: string | number = '',
   orderBy: 'score' | 'ts' = 'score',
 ): Promise<ZhihuCommentResponse> => {
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuCommentResponse>(
     `/comment_v5/answers/${id}/root_comment?order_by=${orderBy}&limit=${limit}&offset=${offset}`,
   );
   res.data.data = (res.data.data || []).map(normalizeComment);
@@ -248,7 +404,7 @@ export const getQuestionCommentsV5 = async (
   offset: string | number = '',
   orderBy: 'score' | 'ts' = 'score',
 ): Promise<ZhihuCommentResponse> => {
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuCommentResponse>(
     `/comment_v5/questions/${id}/root_comment?order_by=${orderBy}&limit=${limit}&offset=${offset}`,
   );
   res.data.data = (res.data.data || []).map(normalizeComment);
@@ -261,7 +417,7 @@ export const getArticleCommentsV5 = async (
   offset: string | number = '',
   orderBy: 'score' | 'ts' = 'score',
 ): Promise<ZhihuCommentResponse> => {
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuCommentResponse>(
     `/comment_v5/articles/${id}/root_comment?order_by=${orderBy}&limit=${limit}&offset=${offset}`,
   );
   res.data.data = (res.data.data || []).map(normalizeComment);
@@ -274,7 +430,7 @@ export const getPinCommentsV5 = async (
   offset: string | number = '',
   orderBy: 'score' | 'ts' = 'score',
 ): Promise<ZhihuCommentResponse> => {
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuCommentResponse>(
     `/comment_v5/pins/${id}/root_comment?order_by=${orderBy}&limit=${limit}&offset=${offset}`,
   );
   res.data.data = (res.data.data || []).map(normalizeComment);
@@ -284,22 +440,28 @@ export const getPinCommentsV5 = async (
 export const createPinComment = async (
   id: string | number,
   content: string,
-): Promise<any> => {
-  const res = await apiClient.post(`/pins/${id}/comments`, {
-    content,
-    type: 'comment',
-  });
+): Promise<CreateCommentResponse> => {
+  const res = await apiClient.post<CreateCommentResponse>(
+    `/pins/${id}/comments`,
+    {
+      content,
+      type: 'comment',
+    },
+  );
   return res.data;
 };
 
 export const createArticleComment = async (
   id: string | number,
   content: string,
-): Promise<any> => {
-  const res = await apiClient.post(`/articles/${id}/comments`, {
-    content,
-    type: 'comment',
-  });
+): Promise<CreateCommentResponse> => {
+  const res = await apiClient.post<CreateCommentResponse>(
+    `/articles/${id}/comments`,
+    {
+      content,
+      type: 'comment',
+    },
+  );
   return res.data;
 };
 
@@ -308,59 +470,90 @@ export const getChildCommentsV5 = async (
   limit = 20,
   offset: string | number = '',
 ): Promise<ZhihuCommentResponse> => {
-  const res = await apiClient.get(
+  const res = await apiClient.get<ZhihuCommentResponse>(
     `/comment_v5/comment/${id}/child_comment?order_by=ts&limit=${limit}&offset=${offset}`,
   );
   res.data.data = (res.data.data || []).map(normalizeComment);
   return res.data;
 };
 
+export const deleteComment = async (
+  id: string | number,
+): Promise<DeleteCommentResponse> => {
+  const res = await apiClient.delete<DeleteCommentResponse>(
+    `/comment_v5/comment/${encodeURIComponent(String(id))}`,
+  );
+  return res.data;
+};
+
 /**
  * 格式化评论数据，兼容 v4 和 v5 结构
  */
-const normalizeComment = (comment: any): CommentItem => {
-  if (!comment) return comment;
+type CommentRecord = Record<string, unknown>;
+
+const isCommentRecord = (value: unknown): value is CommentRecord =>
+  typeof value === 'object' && value !== null;
+
+const normalizeAuthor = (value: unknown): CommentAuthor | undefined => {
+  if (!isCommentRecord(value)) return undefined;
+
+  if (isCommentRecord(value.member)) {
+    return {
+      role: typeof value.role === 'string' ? value.role : undefined,
+      member: value.member as unknown as CommentMember,
+    };
+  }
+
+  return { member: value as unknown as CommentMember };
+};
+
+const normalizeComment = (comment: unknown): CommentItem => {
+  if (!isCommentRecord(comment)) return comment as CommentItem;
+
+  const normalized = { ...comment } as unknown as CommentItem;
 
   // 1. 处理作者结构 (V5 扁平化了)
-  if (comment.author && !comment.author.member) {
-    comment.author = { member: { ...comment.author } };
+  const author = normalizeAuthor(comment.author);
+  if (author) {
+    normalized.author = author;
   }
 
   // 2. 处理回复对象的作者结构
-  if (comment.reply_to_author && !comment.reply_to_author.member) {
-    comment.reply_to_author = { member: { ...comment.reply_to_author } };
+  if (comment.reply_to_author) {
+    normalized.reply_to_author =
+      normalizeAuthor(comment.reply_to_author) ?? null;
   }
 
   // 3. 处理点赞数 (V5 是 like_count)
-  if (comment.vote_count === undefined && comment.like_count !== undefined) {
-    comment.vote_count = comment.like_count;
+  if (
+    normalized.vote_count === undefined &&
+    typeof comment.like_count === 'number'
+  ) {
+    normalized.vote_count = comment.like_count;
   }
 
   // 4. 处理点赞状态 (V5 是 liked)
-  if (!comment.relationship && comment.liked !== undefined) {
-    comment.relationship = {
+  if (!normalized.relationship && typeof comment.liked === 'boolean') {
+    normalized.relationship = {
       voting: comment.liked ? 1 : 0,
     };
   }
 
   // 5. 递归处理子评论 (V5 有时候会自带部分子评论)
-  if (comment.child_comments && Array.isArray(comment.child_comments)) {
-    comment.child_comments = comment.child_comments.map(normalizeComment);
+  if (Array.isArray(comment.child_comments)) {
+    normalized.child_comments = comment.child_comments.map(normalizeComment);
   }
 
   // 6. 处理 IP 属地 (V5 使用 comment_tag 结构)
-  if (
-    !comment.address_text &&
-    comment.comment_tag &&
-    Array.isArray(comment.comment_tag)
-  ) {
+  if (!normalized.address_text && Array.isArray(comment.comment_tag)) {
     const ipTag = comment.comment_tag.find(
-      (tag: any) => tag.type === 'ip_info',
+      (tag): tag is CommentRecord =>
+        isCommentRecord(tag) && tag.type === 'ip_info',
     );
-    if (ipTag) {
-      comment.address_text = ipTag.text;
+    if (ipTag && typeof ipTag.text === 'string') {
+      normalized.address_text = ipTag.text;
     }
   }
 
-  return comment;
+  return normalized;
 };

--- a/api/zhihu/comment.ts
+++ b/api/zhihu/comment.ts
@@ -221,13 +221,15 @@ export interface CreateCommentResponse {
   id?: string | number;
   type?: string;
   content?: string;
+  reply_comment_id?: string | number | null;
+  reply_root_comment_id?: string | number | null;
   [key: string]: unknown;
 }
 
 export interface CreateCommentPayload {
   content: string;
   type: 'comment';
-  reply_to_comment_id?: string | number;
+  reply_comment_id?: string | number;
 }
 
 export const getComment = async (id: string | number): Promise<CommentItem> => {
@@ -375,7 +377,7 @@ export const createCommentV5 = async (
     type: 'comment',
   };
   if (replyToCommentId !== undefined) {
-    payload.reply_to_comment_id = replyToCommentId;
+    payload.reply_comment_id = replyToCommentId;
   }
 
   const res = await apiClient.post<CreateCommentResponse>(

--- a/api/zhihu/image.ts
+++ b/api/zhihu/image.ts
@@ -1,0 +1,375 @@
+import { CryptoDigestAlgorithm, digest } from 'expo-crypto';
+import * as FileSystem from 'expo-file-system/legacy';
+import apiClient from '../client';
+
+export interface LocalImageAsset {
+  uri: string;
+  width: number;
+  height: number;
+  mimeType?: string | null;
+  fileName?: string | null;
+}
+
+export interface ZhihuImage {
+  imageId: string;
+  imageKey?: string;
+  src: string;
+  originalSrc?: string;
+}
+
+export interface UploadedImage extends ZhihuImage {
+  width: number;
+  height: number;
+}
+
+interface UploadToken {
+  access_key: string;
+  access_token: string;
+  access_timestamp: number;
+  access_id: string;
+}
+
+interface UploadFile {
+  image_id: string | number;
+  state: number;
+  publish_state: number;
+  object_key?: string;
+}
+
+interface ImageCreateResponse {
+  upload_token?: UploadToken;
+  upload_vendor?: string;
+  upload_file?: UploadFile;
+}
+
+interface ImageDetailResponse {
+  status?: string;
+  src?: string;
+  original_hash?: string;
+  original_src?: string;
+}
+
+const IMAGE_API_URL = 'https://api.zhihu.com/images';
+const IMAGE_UPLOAD_URL = 'https://zhihu-pics-upload.zhimg.com';
+const OSS_BUCKET_NAME = 'zhihu-pics';
+const OSS_USER_AGENT = 'aliyun-sdk-js/6.8.0 Expo 55 React Native';
+
+function encodeUtf8(value: string): Uint8Array {
+  const encoded = encodeURIComponent(value);
+  const bytes: number[] = [];
+  for (let index = 0; index < encoded.length; index += 1) {
+    if (encoded[index] === '%') {
+      bytes.push(Number.parseInt(encoded.slice(index + 1, index + 3), 16));
+      index += 2;
+    } else {
+      bytes.push(encoded.charCodeAt(index));
+    }
+  }
+  return Uint8Array.from(bytes);
+}
+
+function concatenateBytes(...arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((sum, array) => sum + array.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const array of arrays) {
+    result.set(array, offset);
+    offset += array.length;
+  }
+  return result;
+}
+
+function digestBytes(
+  algorithm: CryptoDigestAlgorithm,
+  bytes: Uint8Array,
+): Promise<ArrayBuffer> {
+  // Keep the runtime value as Uint8Array. Android's Expo module bridges
+  // TypedArray correctly but cannot convert a standalone ArrayBuffer.
+  return digest(algorithm, bytes as unknown as BufferSource);
+}
+
+function toBase64(bytes: Uint8Array): string {
+  const alphabet =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  let result = '';
+  for (let index = 0; index < bytes.length; index += 3) {
+    const first = bytes[index];
+    const second = bytes[index + 1];
+    const third = bytes[index + 2];
+    const bits = (first << 16) | ((second ?? 0) << 8) | (third ?? 0);
+    result += alphabet[(bits >> 18) & 63];
+    result += alphabet[(bits >> 12) & 63];
+    result += second === undefined ? '=' : alphabet[(bits >> 6) & 63];
+    result += third === undefined ? '=' : alphabet[bits & 63];
+  }
+  return result;
+}
+
+async function hmacSha1Base64(
+  secret: string,
+  message: string,
+): Promise<string> {
+  const blockSize = 64;
+  const secretBytes = encodeUtf8(secret);
+  const normalizedSecret =
+    secretBytes.length > blockSize
+      ? new Uint8Array(
+          await digestBytes(CryptoDigestAlgorithm.SHA1, secretBytes),
+        )
+      : secretBytes;
+  const paddedSecret = new Uint8Array(blockSize);
+  paddedSecret.set(normalizedSecret);
+
+  const innerPad = new Uint8Array(blockSize);
+  const outerPad = new Uint8Array(blockSize);
+  for (let index = 0; index < blockSize; index += 1) {
+    innerPad[index] = paddedSecret[index] ^ 0x36;
+    outerPad[index] = paddedSecret[index] ^ 0x5c;
+  }
+
+  const innerHash = new Uint8Array(
+    await digestBytes(
+      CryptoDigestAlgorithm.SHA1,
+      concatenateBytes(innerPad, encodeUtf8(message)),
+    ),
+  );
+  const signature = new Uint8Array(
+    await digestBytes(
+      CryptoDigestAlgorithm.SHA1,
+      concatenateBytes(outerPad, innerHash),
+    ),
+  );
+  return toBase64(signature);
+}
+
+function canonicalizeOssHeaders(headers: Record<string, string>): string {
+  return Object.entries(headers)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key.toLowerCase()}:${value.trim()}\n`)
+    .join('');
+}
+
+async function createOssAuthorization(
+  token: UploadToken,
+  objectKey: string,
+  mimeType: string,
+  ossDate: string,
+  ossUserAgent: string,
+): Promise<string> {
+  const ossHeaders = {
+    'x-oss-date': ossDate,
+    'x-oss-security-token': token.access_token,
+    'x-oss-user-agent': ossUserAgent,
+  };
+  const normalizedObjectKey = objectKey.startsWith('/')
+    ? objectKey.slice(1)
+    : objectKey;
+  // The upload host omits the bucket from its URL, but OSS V1 still expects
+  // the bucket name in CanonicalizedResource.
+  const canonicalizedResource = `/${OSS_BUCKET_NAME}/${normalizedObjectKey}`;
+  const stringToSign = [
+    'PUT',
+    '',
+    mimeType,
+    // OSS V1 uses x-oss-date as the Date line when no separate Date header is sent.
+    ossDate,
+    `${canonicalizeOssHeaders(ossHeaders)}${canonicalizedResource}`,
+  ].join('\n');
+  const signature = await hmacSha1Base64(token.access_key, stringToSign);
+  return `OSS ${token.access_id}:${signature}`;
+}
+
+function getImageMimeType(asset: LocalImageAsset): string {
+  const mimeType = asset.mimeType?.toLowerCase();
+  if (mimeType?.startsWith('image/')) return mimeType;
+
+  const extension = asset.fileName?.split('.').pop()?.toLowerCase();
+  if (extension === 'png') return 'image/png';
+  if (extension === 'gif') return 'image/gif';
+  if (extension === 'webp') return 'image/webp';
+  return 'image/jpeg';
+}
+
+function getImageDimensions(asset: LocalImageAsset) {
+  return {
+    width: Math.max(1, Math.round(asset.width)),
+    height: Math.max(1, Math.round(asset.height)),
+  };
+}
+
+function getResponseHeader(
+  headers: Record<string, string>,
+  name: string,
+): string | undefined {
+  const entry = Object.entries(headers).find(
+    ([key]) => key.toLowerCase() === name.toLowerCase(),
+  );
+  return entry?.[1];
+}
+
+function getXmlValue(body: string, tag: string): string | undefined {
+  const match = body.match(new RegExp(`<${tag}>\\s*([^<]*?)\\s*</${tag}>`));
+  return match?.[1];
+}
+
+function sanitizeOssText(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const sanitized = value.replace(/\s+/g, ' ').trim().slice(0, 160);
+  return sanitized || undefined;
+}
+
+function createOssUploadError(
+  status: number,
+  body: string,
+  headers: Record<string, string>,
+): Error {
+  const code = sanitizeOssText(getXmlValue(body, 'Code'));
+  const message = sanitizeOssText(getXmlValue(body, 'Message'));
+  const requestId = sanitizeOssText(
+    getXmlValue(body, 'RequestId') ||
+      getResponseHeader(headers, 'x-oss-request-id'),
+  );
+  const details = [
+    code,
+    message,
+    requestId ? `request id: ${requestId}` : undefined,
+  ].filter(Boolean);
+  return new Error(
+    `图片上传失败（${status}）${details.length ? `：${details.join('；')}` : ''}`,
+  );
+}
+
+function normalizeImage(
+  imageId: string | number,
+  data: ImageDetailResponse,
+): ZhihuImage {
+  if (data.status !== 'success' || !data.src) {
+    throw new Error('知乎图片尚未处理完成');
+  }
+
+  return {
+    imageId: String(imageId),
+    imageKey: data.original_hash,
+    src: data.src,
+    originalSrc: data.original_src,
+  };
+}
+
+/** Fetch the public image URLs for a Zhihu image id. */
+export async function getImage(imageId: string | number): Promise<ZhihuImage> {
+  const response = await apiClient.get<ImageDetailResponse>(
+    `${IMAGE_API_URL}/${encodeURIComponent(String(imageId))}`,
+  );
+  return normalizeImage(imageId, response.data);
+}
+
+async function getImageAfterUpload(
+  imageId: string | number,
+): Promise<ZhihuImage> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    try {
+      return await getImage(imageId);
+    } catch (error) {
+      lastError = error;
+      if (attempt === 3) break;
+      await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('知乎图片尚未处理完成');
+}
+
+async function uploadToObjectStorage(
+  asset: LocalImageAsset,
+  token: UploadToken,
+  objectKey: string,
+): Promise<void> {
+  const mimeType = getImageMimeType(asset);
+  const ossDate = new Date().toUTCString();
+  const authorization = await createOssAuthorization(
+    token,
+    objectKey,
+    mimeType,
+    ossDate,
+    OSS_USER_AGENT,
+  );
+  const uploadResponse = await FileSystem.uploadAsync(
+    `${IMAGE_UPLOAD_URL}/${objectKey}`,
+    asset.uri,
+    {
+      httpMethod: 'PUT',
+      uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
+      headers: {
+        'Content-Type': mimeType,
+        authorization,
+        'x-oss-date': ossDate,
+        'x-oss-security-token': token.access_token,
+        'x-oss-user-agent': OSS_USER_AGENT,
+      },
+    },
+  );
+
+  if (uploadResponse.status < 200 || uploadResponse.status >= 300) {
+    throw createOssUploadError(
+      uploadResponse.status,
+      uploadResponse.body,
+      uploadResponse.headers,
+    );
+  }
+}
+
+async function markImageUploadSuccessful(imageId: string | number) {
+  await apiClient.put(
+    `${IMAGE_API_URL}/${encodeURIComponent(String(imageId))}/uploading_status`,
+    { upload_result: 'success' },
+  );
+}
+
+/**
+ * Create or reuse a Zhihu image and return its resolved public URLs.
+ * The source is passed through because the same image service is used by
+ * multiple Zhihu publishing surfaces, not only comments.
+ */
+export async function uploadImage(
+  asset: LocalImageAsset,
+  source = 'comment',
+): Promise<UploadedImage> {
+  const fileInfo = await FileSystem.getInfoAsync(asset.uri, { md5: true });
+  if (!fileInfo.exists || !fileInfo.md5) {
+    throw new Error('无法读取图片文件');
+  }
+
+  const response = await apiClient.post<ImageCreateResponse>(IMAGE_API_URL, {
+    image_hash: fileInfo.md5,
+    source,
+  });
+  const file = response.data.upload_file;
+  if (file?.image_id === undefined || file.image_id === null) {
+    throw new Error('知乎图片上传信息无效');
+  }
+
+  const imageId = String(file.image_id);
+  const needsUpload = file.state !== 1 || file.publish_state !== 1;
+  if (needsUpload) {
+    const token = response.data.upload_token;
+    if (!token?.access_id || !token.access_key || !token.access_token) {
+      throw new Error('知乎图片上传凭证无效');
+    }
+    if (!file.object_key) {
+      throw new Error('知乎图片上传路径无效');
+    }
+
+    await uploadToObjectStorage(asset, token, file.object_key);
+    await markImageUploadSuccessful(imageId);
+  }
+
+  const image = await getImageAfterUpload(imageId);
+  const dimensions = getImageDimensions(asset);
+  return {
+    ...image,
+    imageKey: file.object_key ?? image.imageKey,
+    ...dimensions,
+  };
+}

--- a/api/zhihu/index.ts
+++ b/api/zhihu/index.ts
@@ -13,6 +13,7 @@ export * from './daily';
 export * from './feed';
 export * from './following';
 export * from './history';
+export * from './image';
 export * from './me';
 export * from './member';
 export * from './moments';

--- a/api/zhihu/voters.ts
+++ b/api/zhihu/voters.ts
@@ -1,32 +1,60 @@
 import apiClient from '../client';
 
+export interface ZhihuApiErrorDetail {
+  code: number;
+  name: string;
+  message: string;
+  [key: string]: unknown;
+}
+
+export interface ZhihuErrorResponse {
+  error: ZhihuApiErrorDetail;
+}
+
+export interface ZhihuVoteResponse {
+  success?: boolean;
+  [key: string]: unknown;
+}
+
 export const voteContent = async (
   id: string | number,
   type: 'answers' | 'articles' | 'questions' | 'pins' | 'comments',
   voteType: 'up' | 'neutral' | 'down' | 'like' | 'unlike',
-) => {
+): Promise<ZhihuVoteResponse> => {
   if (type === 'pins') {
     if (voteType === 'like' || voteType === 'up') {
-      const res = await apiClient.post(`/pins/${id}/voters/up`, {
-        not_sync_moments: true,
-      });
+      const res = await apiClient.post<ZhihuVoteResponse>(
+        `/pins/${id}/voters/up`,
+        {
+          not_sync_moments: true,
+        },
+      );
       return res.data;
     } else {
-      const res = await apiClient.delete(`/pins/${id}/voters/up`);
+      const res = await apiClient.delete<ZhihuVoteResponse>(
+        `/pins/${id}/voters/up`,
+      );
       return res.data;
     }
   } else if (type === 'comments') {
     if (voteType === 'up' || voteType === 'like') {
-      const res = await apiClient.post(`/comments/${id}/like`);
+      const res = await apiClient.post<ZhihuVoteResponse>(
+        `/comments/${encodeURIComponent(String(id))}/like`,
+      );
       return res.data;
     } else {
-      const res = await apiClient.delete(`/comments/${id}/like`);
+      const res = await apiClient.delete<ZhihuVoteResponse>(
+        `/comments/${encodeURIComponent(String(id))}/like`,
+      );
       return res.data;
     }
   } else {
-    const res = await apiClient.post(`/${type}/${id}/voters`, {
-      type: voteType,
-    });
+    const res = await apiClient.post<ZhihuVoteResponse>(
+      `/${type}/${id}/voters`,
+      {
+        type: voteType,
+      },
+    );
     return res.data;
   }
 };

--- a/app.json
+++ b/app.json
@@ -261,6 +261,12 @@
       "expo-sharing",
       "expo-file-system",
       [
+        "expo-image-picker",
+        {
+          "photosPermission": "允许知乎--访问你的照片，以便在评论中上传图片。"
+        }
+      ],
+      [
         "@sentry/react-native",
         {
           "organization": "huamumu",

--- a/app/comments/[id].tsx
+++ b/app/comments/[id].tsx
@@ -15,7 +15,7 @@ import {
   Keyboard,
   Platform,
   StyleSheet,
-  TextInput,
+  type TextInput,
   useWindowDimensions,
 } from 'react-native';
 import Reanimated, {
@@ -26,11 +26,14 @@ import Reanimated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   type CommentItem,
+  type CommentResourceType,
   createAnswerComment,
   createArticleComment,
   createCommentReply,
+  createCommentV5,
   createPinComment,
   createQuestionComment,
+  deleteComment,
   getAnswerComments,
   getArticleCommentsV5 as getArticleComments,
   getPinCommentsV5 as getPinComments,
@@ -38,12 +41,18 @@ import {
 } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
 import { CommentActionSheet } from '@/components/CommentActionSheet';
+import {
+  CommentComposer,
+  type CommentDraft,
+} from '@/components/CommentComposer';
 import { CommentContent } from '@/components/CommentContent';
 import { LikeButton } from '@/components/LikeButton';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
 import { formatDate } from '@/utils/date';
+import { buildZhihuContent, buildZhihuImageHtml } from '@/utils/zhihuContent';
+import { getZhihuErrorMessage } from '@/utils/zhihuError';
 
 export default function CommentScreen() {
   const { id, type, segmentId, count, text } = useLocalSearchParams<{
@@ -59,11 +68,13 @@ export default function CommentScreen() {
     null,
   );
   const [commentAction, setCommentAction] = useState<{
+    id: string | number;
     htmlContent: string;
     authorName: string;
+    canDelete: boolean;
   } | null>(null);
   const inputRef = React.useRef<TextInput>(null);
-  const _queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   const _insets = useSafeAreaInsets();
   const colorScheme = useColorScheme();
   const borderColor = Colors[colorScheme].border;
@@ -74,6 +85,14 @@ export default function CommentScreen() {
   // 减去头像(32) + 间距(12) + 左右padding(30)
   const contentWidth = screenWidth - 32 - 12 - 30;
   const insets = _insets;
+  const commentResourceType: CommentResourceType =
+    type === 'question'
+      ? 'questions'
+      : type === 'article'
+        ? 'articles'
+        : type === 'pin'
+          ? 'pins'
+          : 'answers';
 
   // 键盘高度动画：解决键盘收起后输入框无法回到底部的 bug
   const keyboardHeight = useSharedValue(0);
@@ -145,7 +164,17 @@ export default function CommentScreen() {
   const comments = data?.pages.flatMap((page: any) => page.data || []) || [];
 
   const mutation = useMutation({
-    mutationFn: (content: string) => {
+    mutationFn: async ({ text: commentText, images }: CommentDraft) => {
+      const imageHtml = images.map(buildZhihuImageHtml).join('<br/>');
+      const content = buildZhihuContent(commentText, imageHtml);
+      if (replyTo && !segmentId) {
+        return createCommentV5(
+          commentResourceType,
+          id as string,
+          content,
+          replyTo.id,
+        );
+      }
       if (replyTo) return createCommentReply(replyTo.id, content);
       if (type === 'question')
         return createQuestionComment(id as string, content);
@@ -160,25 +189,62 @@ export default function CommentScreen() {
       setReplyTo(null);
       refetch();
     },
-    onError: (err: any) =>
-      Alert.alert('发布失败', err.response?.data?.error?.message || '未知错误'),
+    onError: (err: unknown) =>
+      Alert.alert('发布失败', getZhihuErrorMessage(err)),
   });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (commentId: string | number) => {
+      const response = await deleteComment(commentId);
+      if (!response.success) throw new Error('知乎未确认评论删除成功');
+      return response;
+    },
+    onSuccess: () => {
+      setCommentAction(null);
+      void refetch();
+      void queryClient.invalidateQueries({ queryKey: ['comments'] });
+      Alert.alert('删除成功', '评论已删除喵！');
+    },
+    onError: (err: unknown) =>
+      Alert.alert('删除失败', getZhihuErrorMessage(err)),
+  });
+
+  const submitComment = async (draft: CommentDraft) => {
+    await mutation.mutateAsync(draft);
+  };
 
   const goToProfile = (urlToken: string | number) => {
     if (urlToken) router.push(`/user/${urlToken}`);
   };
 
-  const handleLongPressComment = (htmlContent: string, authorName: string) => {
-    setCommentAction({ htmlContent, authorName });
+  const canDeleteComment = (item: CommentItem) =>
+    item.can_delete === true || item.allow_delete === true;
+
+  const requestDelete = (commentId: string | number) => {
+    Alert.alert('确认删除', '确定要删除这条评论吗？此操作不可撤销喵。', [
+      { text: '取消', style: 'cancel' },
+      {
+        text: '删除',
+        style: 'destructive',
+        onPress: () => deleteMutation.mutate(commentId),
+      },
+    ]);
+  };
+
+  const handleLongPressComment = (item: CommentItem) => {
+    setCommentAction({
+      id: item.id,
+      htmlContent: item.content,
+      authorName: item.author.member.name,
+      canDelete: canDeleteComment(item),
+    });
   };
 
   const renderComment = ({ item }: { item: CommentItem }) => {
     return (
       <BouncyButton
         accessible={false}
-        onLongPress={() =>
-          handleLongPressComment(item.content, item.author.member.name)
-        }
+        onLongPress={() => handleLongPressComment(item)}
         delayLongPress={400}
         style={{
           paddingHorizontal: 15,
@@ -254,6 +320,20 @@ export default function CommentScreen() {
                     回复
                   </Text>
                 </BouncyButton>
+                {canDeleteComment(item) && (
+                  <BouncyButton
+                    disabled={deleteMutation.isPending}
+                    onPress={() => requestDelete(item.id)}
+                    style={{ marginLeft: 15, borderRadius: 4 }}
+                  >
+                    <Text
+                      className="text-xs font-medium py-1"
+                      style={{ color: Colors[colorScheme].danger }}
+                    >
+                      删除
+                    </Text>
+                  </BouncyButton>
+                )}
               </View>
             </View>
 
@@ -272,7 +352,9 @@ export default function CommentScreen() {
                   router.push(
                     `/comments/replies/${item.id}?parent=${encodeURIComponent(
                       JSON.stringify(item),
-                    )}`,
+                    )}&resourceId=${encodeURIComponent(
+                      String(id),
+                    )}&resourceType=${encodeURIComponent(commentResourceType)}`,
                   )
                 }
               >
@@ -447,73 +529,26 @@ export default function CommentScreen() {
           style={{
             borderRadius: 30,
             overflow: 'hidden',
-            borderWidth: StyleSheet.hairlineWidth,
-            borderColor,
-            paddingHorizontal: 5,
-            backgroundColor:
-              colorScheme === 'dark'
-                ? 'rgba(26,26,26,0.85)'
-                : 'rgba(255,255,255,0.9)',
           }}
         >
-          {replyTo && (
-            <View className="flex-row justify-between items-center px-[15px] pt-2.5 pb-0.5">
-              <Text type="secondary" className="text-xs">
-                正在回复 {replyTo.name}
-              </Text>
-              <BouncyButton
-                onPress={() => setReplyTo(null)}
-                style={{ borderRadius: 8 }}
-              >
-                <Ionicons
-                  name="close-circle"
-                  size={16}
-                  color={Colors[colorScheme].textSecondary}
-                />
-              </BouncyButton>
-            </View>
-          )}
-          <View className="flex-row items-end px-1 py-1">
-            <TextInput
-              ref={inputRef}
-              className="flex-1 min-h-[40px] max-h-[100px] px-3 pt-2.5 pb-2.5"
-              style={{ color: textColor, fontSize: 15 }}
-              placeholder={
-                replyTo
-                  ? `回复 ${replyTo.name}...`
-                  : '既然来了，就留下点什么吧...'
-              }
-              placeholderTextColor="#999"
-              value={inputText}
-              onChangeText={setInputText}
-              multiline
-              maxLength={1000}
-            />
-            <BouncyButton
-              disabled={!inputText.trim() || mutation.isPending}
-              onPress={() => mutation.mutate(inputText.trim())}
-              style={{
-                height: 40,
-                justifyContent: 'center',
-                paddingHorizontal: 15,
-                borderRadius: 20,
-              }}
-            >
-              {mutation.isPending ? (
-                <ActivityIndicator size="small" color={tintColor} />
-              ) : (
-                <Text
-                  className="font-semibold text-base"
-                  style={{
-                    color: tintColor,
-                    opacity: inputText.trim() ? 1 : 0.5,
-                  }}
-                >
-                  发布
-                </Text>
-              )}
-            </BouncyButton>
-          </View>
+          <CommentComposer
+            colorScheme={colorScheme}
+            borderColor={borderColor}
+            inputRef={inputRef}
+            inputText={inputText}
+            isSubmitting={mutation.isPending}
+            onChangeText={setInputText}
+            onSubmit={submitComment}
+            onCancelReply={() => setReplyTo(null)}
+            placeholder={
+              replyTo
+                ? `回复 ${replyTo.name}...`
+                : '既然来了，就留下点什么吧...'
+            }
+            replyToName={replyTo?.name}
+            textColor={textColor}
+            tintColor={tintColor}
+          />
         </BlurView>
       </Reanimated.View>
 
@@ -521,6 +556,10 @@ export default function CommentScreen() {
         visible={commentAction !== null}
         htmlContent={commentAction?.htmlContent ?? null}
         authorName={commentAction?.authorName ?? null}
+        canDelete={commentAction?.canDelete ?? false}
+        onDelete={() => {
+          if (commentAction) requestDelete(commentAction.id);
+        }}
         onClose={() => setCommentAction(null)}
       />
     </View>

--- a/app/comments/replies/[id].tsx
+++ b/app/comments/replies/[id].tsx
@@ -1,4 +1,3 @@
-import { Ionicons } from '@expo/vector-icons';
 import { FlashList } from '@shopify/flash-list';
 import {
   useInfiniteQuery,
@@ -16,7 +15,7 @@ import {
   Keyboard,
   Platform,
   StyleSheet,
-  TextInput,
+  type TextInput,
   useWindowDimensions,
 } from 'react-native';
 import Reanimated, {
@@ -27,35 +26,49 @@ import Reanimated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   type CommentItem,
+  type CommentResourceType,
   createCommentReply,
+  createCommentV5,
+  deleteComment,
   getChildCommentsV5 as getChildComments,
   getComment,
 } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
 import { CommentActionSheet } from '@/components/CommentActionSheet';
+import {
+  CommentComposer,
+  type CommentDraft,
+} from '@/components/CommentComposer';
 import { CommentContent } from '@/components/CommentContent';
 import { LikeButton } from '@/components/LikeButton';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
 import { formatDate } from '@/utils/date';
+import { buildZhihuContent, buildZhihuImageHtml } from '@/utils/zhihuContent';
+import { getZhihuErrorMessage } from '@/utils/zhihuError';
 
 export default function ReplyDetailScreen() {
-  const { id, parent } = useLocalSearchParams<{
+  const { id, parent, resourceId, resourceType } = useLocalSearchParams<{
     id: string;
     parent?: string;
+    resourceId?: string;
+    resourceType?: string;
   }>();
   const [inputText, setInputText] = useState('');
   const [replyTo, setReplyTo] = useState<{ id: string; name: string } | null>(
     null,
   );
   const [commentAction, setCommentAction] = useState<{
+    id: string | number;
     htmlContent: string;
     authorName: string;
+    canDelete: boolean;
+    returnToParent: boolean;
   } | null>(null);
   const inputRef = useRef<TextInput>(null);
   const router = useRouter();
-  const _queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   const _insets = useSafeAreaInsets();
   const colorScheme = useColorScheme();
   const borderColor = Colors[colorScheme].border;
@@ -65,6 +78,13 @@ export default function ReplyDetailScreen() {
   // 减去头像(32) + 间距(12) + 左右padding(30)
   const contentWidth = screenWidth - 32 - 12 - 30;
   const insets = _insets;
+  const v5ResourceType: CommentResourceType | null =
+    resourceType === 'answers' ||
+    resourceType === 'questions' ||
+    resourceType === 'articles' ||
+    resourceType === 'pins'
+      ? resourceType
+      : null;
 
   // 键盘高度动画：解决键盘收起后输入框无法回到底部的 bug
   const keyboardHeight = useSharedValue(0);
@@ -146,37 +166,102 @@ export default function ReplyDetailScreen() {
     0;
 
   const mutation = useMutation({
-    mutationFn: (content: string) =>
-      createCommentReply(
+    mutationFn: async ({ text: commentText, images }: CommentDraft) => {
+      const imageHtml = images.map(buildZhihuImageHtml).join('<br/>');
+      const content = buildZhihuContent(commentText, imageHtml);
+      if (resourceId && v5ResourceType) {
+        return createCommentV5(
+          v5ResourceType,
+          resourceId,
+          content,
+          replyTo?.id || id,
+        );
+      }
+      return createCommentReply(
         id as string,
         content,
         replyTo ? { reply_to_comment_id: replyTo.id } : {},
-      ),
+      );
+    },
     onSuccess: () => {
       Alert.alert('发布成功喵！');
       setInputText('');
       setReplyTo(null);
       refetch();
     },
-    onError: (err: any) =>
-      Alert.alert('发布失败', err.response?.data?.error?.message || '未知错误'),
+    onError: (err: unknown) =>
+      Alert.alert('发布失败', getZhihuErrorMessage(err)),
   });
+
+  const deleteMutation = useMutation({
+    mutationFn: async ({
+      commentId,
+      returnToParent,
+    }: {
+      commentId: string | number;
+      returnToParent: boolean;
+    }) => {
+      const response = await deleteComment(commentId);
+      if (!response.success) throw new Error('知乎未确认评论删除成功');
+      return { response, returnToParent };
+    },
+    onSuccess: ({ returnToParent }) => {
+      setCommentAction(null);
+      void queryClient.invalidateQueries({ queryKey: ['comments'] });
+      if (returnToParent) {
+        router.back();
+      } else {
+        void refetch();
+      }
+      Alert.alert('删除成功', '评论已删除喵！');
+    },
+    onError: (err: unknown) =>
+      Alert.alert('删除失败', getZhihuErrorMessage(err)),
+  });
+
+  const submitComment = async (draft: CommentDraft) => {
+    await mutation.mutateAsync(draft);
+  };
 
   const goToProfile = (urlToken: string | number) => {
     if (urlToken) router.push(`/user/${urlToken}`);
   };
 
-  const handleLongPressComment = (htmlContent: string, authorName: string) => {
-    setCommentAction({ htmlContent, authorName });
+  const canDeleteComment = (item: CommentItem) =>
+    item.can_delete === true || item.allow_delete === true;
+
+  const requestDelete = (
+    commentId: string | number,
+    returnToParent = false,
+  ) => {
+    Alert.alert('确认删除', '确定要删除这条评论吗？此操作不可撤销喵。', [
+      { text: '取消', style: 'cancel' },
+      {
+        text: '删除',
+        style: 'destructive',
+        onPress: () => deleteMutation.mutate({ commentId, returnToParent }),
+      },
+    ]);
+  };
+
+  const handleLongPressComment = (
+    item: CommentItem,
+    returnToParent = false,
+  ) => {
+    setCommentAction({
+      id: item.id,
+      htmlContent: item.content,
+      authorName: item.author.member.name,
+      canDelete: canDeleteComment(item),
+      returnToParent,
+    });
   };
 
   const renderReply = ({ item }: { item: CommentItem }) => {
     return (
       <BouncyButton
         accessible={false}
-        onLongPress={() =>
-          handleLongPressComment(item.content, item.author.member.name)
-        }
+        onLongPress={() => handleLongPressComment(item)}
         delayLongPress={400}
         style={{
           borderRadius: 0,
@@ -267,6 +352,20 @@ export default function ReplyDetailScreen() {
                     回复
                   </Text>
                 </BouncyButton>
+                {canDeleteComment(item) && (
+                  <BouncyButton
+                    disabled={deleteMutation.isPending}
+                    onPress={() => requestDelete(item.id)}
+                    style={{ marginLeft: 15, borderRadius: 4 }}
+                  >
+                    <Text
+                      className="text-xs font-medium py-1"
+                      style={{ color: Colors[colorScheme].danger }}
+                    >
+                      删除
+                    </Text>
+                  </BouncyButton>
+                )}
               </View>
             </View>
           </View>
@@ -288,12 +387,7 @@ export default function ReplyDetailScreen() {
           accessible={false}
           className="flex-row p-[15px] bg-transparent"
           style={{ borderRadius: 0 }}
-          onLongPress={() =>
-            handleLongPressComment(
-              parentComment.content,
-              parentComment.author.member.name,
-            )
-          }
+          onLongPress={() => handleLongPressComment(parentComment, true)}
           delayLongPress={400}
         >
           <BouncyButton
@@ -372,6 +466,20 @@ export default function ReplyDetailScreen() {
                     回复
                   </Text>
                 </BouncyButton>
+                {canDeleteComment(parentComment) && (
+                  <BouncyButton
+                    disabled={deleteMutation.isPending}
+                    onPress={() => requestDelete(parentComment.id, true)}
+                    style={{ marginLeft: 15, borderRadius: 4 }}
+                  >
+                    <Text
+                      className="text-xs font-medium py-1"
+                      style={{ color: Colors[colorScheme].danger }}
+                    >
+                      删除
+                    </Text>
+                  </BouncyButton>
+                )}
               </View>
             </View>
           </View>
@@ -453,71 +561,22 @@ export default function ReplyDetailScreen() {
           style={{
             borderRadius: 30,
             overflow: 'hidden',
-            borderWidth: StyleSheet.hairlineWidth,
-            borderColor,
-            paddingHorizontal: 5,
-            backgroundColor:
-              colorScheme === 'dark'
-                ? 'rgba(26,26,26,0.85)'
-                : 'rgba(255,255,255,0.9)',
           }}
         >
-          {replyTo && (
-            <View className="flex-row justify-between items-center px-[15px] pt-2.5 pb-0.5">
-              <Text type="secondary" className="text-xs">
-                正在回复 {replyTo.name}
-              </Text>
-              <BouncyButton
-                onPress={() => setReplyTo(null)}
-                style={{ borderRadius: 8 }}
-              >
-                <Ionicons
-                  name="close-circle"
-                  size={16}
-                  color={Colors[colorScheme].textSecondary}
-                />
-              </BouncyButton>
-            </View>
-          )}
-          <View className="flex-row items-end px-1 py-1">
-            <TextInput
-              ref={inputRef}
-              className="flex-1 min-h-[35px] max-h-[100px] px-3 pt-2.5 pb-2.5"
-              style={{ color: textColor, fontSize: 15 }}
-              placeholder={
-                replyTo ? `回复 ${replyTo.name}...` : '说点什么吧...'
-              }
-              placeholderTextColor="#999"
-              value={inputText}
-              onChangeText={setInputText}
-              multiline
-              maxLength={1000}
-            />
-            <BouncyButton
-              disabled={!inputText.trim() || mutation.isPending}
-              onPress={() => mutation.mutate(inputText.trim())}
-              style={{
-                height: 40,
-                justifyContent: 'center',
-                paddingHorizontal: 15,
-                borderRadius: 20,
-              }}
-            >
-              {mutation.isPending ? (
-                <ActivityIndicator size="small" color={tintColor} />
-              ) : (
-                <Text
-                  className="font-semibold text-base"
-                  style={{
-                    color: tintColor,
-                    opacity: inputText.trim() ? 1 : 0.5,
-                  }}
-                >
-                  发布
-                </Text>
-              )}
-            </BouncyButton>
-          </View>
+          <CommentComposer
+            colorScheme={colorScheme}
+            borderColor={borderColor}
+            inputRef={inputRef}
+            inputText={inputText}
+            isSubmitting={mutation.isPending}
+            onChangeText={setInputText}
+            onSubmit={submitComment}
+            onCancelReply={() => setReplyTo(null)}
+            placeholder={replyTo ? `回复 ${replyTo.name}...` : '说点什么吧...'}
+            replyToName={replyTo?.name}
+            textColor={textColor}
+            tintColor={tintColor}
+          />
         </BlurView>
       </Reanimated.View>
 
@@ -525,6 +584,12 @@ export default function ReplyDetailScreen() {
         visible={commentAction !== null}
         htmlContent={commentAction?.htmlContent ?? null}
         authorName={commentAction?.authorName ?? null}
+        canDelete={commentAction?.canDelete ?? false}
+        onDelete={() => {
+          if (commentAction) {
+            requestDelete(commentAction.id, commentAction.returnToParent);
+          }
+        }}
         onClose={() => setCommentAction(null)}
       />
     </View>

--- a/components/CommentActionSheet.tsx
+++ b/components/CommentActionSheet.tsx
@@ -6,6 +6,8 @@ interface CommentActionSheetProps {
   visible: boolean;
   htmlContent: string | null;
   authorName: string | null;
+  canDelete?: boolean;
+  onDelete?: () => void;
   onClose: () => void;
 }
 
@@ -23,10 +25,35 @@ export function CommentActionSheet({
   visible,
   htmlContent,
   authorName,
+  canDelete = false,
+  onDelete,
   onClose,
 }: CommentActionSheetProps) {
   const commentText = htmlContent ? extractCommentText(htmlContent) : '';
   if (!htmlContent || !authorName || !commentText) return null;
+
+  const options = [
+    {
+      key: 'copy',
+      label: '复制评论',
+      icon: 'copy-outline' as const,
+      onPress: async () => {
+        const copied = await copyToClipboard(commentText);
+        if (copied) showToast(`已复制 @${authorName} 的评论`);
+      },
+    },
+    ...(canDelete && onDelete
+      ? [
+          {
+            key: 'delete',
+            label: '删除评论',
+            icon: 'trash-outline' as const,
+            destructive: true,
+            onPress: onDelete,
+          },
+        ]
+      : []),
+  ];
 
   return (
     <ActionSheet
@@ -34,17 +61,7 @@ export function CommentActionSheet({
       onClose={onClose}
       title={`@${authorName} 的评论`}
       subtitle={commentText}
-      options={[
-        {
-          key: 'copy',
-          label: '复制评论',
-          icon: 'copy-outline',
-          onPress: async () => {
-            const copied = await copyToClipboard(commentText);
-            if (copied) showToast(`已复制 @${authorName} 的评论`);
-          },
-        },
-      ]}
+      options={options}
     />
   );
 }

--- a/components/CommentComposer.tsx
+++ b/components/CommentComposer.tsx
@@ -1,0 +1,330 @@
+import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
+import type React from 'react';
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  StyleSheet,
+  TextInput,
+} from 'react-native';
+import {
+  type LocalImageAsset,
+  type UploadedImage,
+  uploadImage,
+} from '@/api/zhihu/image';
+import { BouncyButton } from '@/components/BouncyButton';
+import { Text, View } from '@/components/Themed';
+import Colors from '@/constants/Colors';
+import { getZhihuErrorMessage } from '@/utils/zhihuError';
+
+export interface CommentDraft {
+  text: string;
+  images: UploadedImage[];
+}
+
+interface SelectedImage {
+  asset: LocalImageAsset;
+  status: 'uploading' | 'uploaded' | 'failed';
+  uploaded?: UploadedImage;
+}
+
+interface CommentComposerProps {
+  colorScheme: 'light' | 'dark';
+  borderColor: string;
+  inputRef: React.RefObject<TextInput | null>;
+  inputText: string;
+  isSubmitting: boolean;
+  onChangeText: (text: string) => void;
+  onSubmit: (draft: CommentDraft) => Promise<void>;
+  onCancelReply: () => void;
+  placeholder: string;
+  replyToName?: string;
+  textColor: string;
+  tintColor: string;
+}
+
+export function CommentComposer({
+  colorScheme,
+  borderColor,
+  inputRef,
+  inputText,
+  isSubmitting,
+  onChangeText,
+  onSubmit,
+  onCancelReply,
+  placeholder,
+  replyToName,
+  textColor,
+  tintColor,
+}: CommentComposerProps) {
+  const [selectedImages, setSelectedImages] = useState<SelectedImage[]>([]);
+  const [isPicking, setIsPicking] = useState(false);
+
+  const uploadSelectedImage = (asset: LocalImageAsset) => {
+    void uploadImage(asset)
+      .then((uploaded) => {
+        setSelectedImages((currentImages) =>
+          currentImages.map((image) =>
+            image.asset.uri === asset.uri
+              ? { ...image, status: 'uploaded', uploaded }
+              : image,
+          ),
+        );
+      })
+      .catch((error: unknown) => {
+        setSelectedImages((currentImages) =>
+          currentImages.map((image) =>
+            image.asset.uri === asset.uri
+              ? { ...image, status: 'failed', uploaded: undefined }
+              : image,
+          ),
+        );
+        Alert.alert('图片上传失败', getZhihuErrorMessage(error));
+      });
+  };
+
+  const chooseImage = async () => {
+    if (isSubmitting || isPicking) return;
+
+    try {
+      const permission =
+        await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!permission.granted) {
+        Alert.alert('需要相册权限', '请允许访问照片，才能在评论中上传图片。');
+        return;
+      }
+
+      setIsPicking(true);
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        allowsEditing: false,
+        allowsMultipleSelection: true,
+        selectionLimit: 0,
+        quality: 1,
+      });
+
+      if (!result.canceled && result.assets.length > 0) {
+        const newImages = result.assets.map((asset) => ({
+          uri: asset.uri,
+          width: asset.width,
+          height: asset.height,
+          mimeType: asset.mimeType,
+          fileName: asset.fileName,
+        }));
+        const existingUris = new Set(
+          selectedImages.map((image) => image.asset.uri),
+        );
+        const uniqueImages = newImages.filter(
+          (image) => !existingUris.has(image.uri),
+        );
+        if (uniqueImages.length > 0) {
+          setSelectedImages((currentImages) => [
+            ...currentImages,
+            ...uniqueImages.map((asset) => ({
+              asset,
+              status: 'uploading' as const,
+            })),
+          ]);
+          uniqueImages.forEach(uploadSelectedImage);
+        }
+      }
+    } catch {
+      Alert.alert('选择图片失败', '暂时无法读取相册，请稍后重试。');
+    } finally {
+      setIsPicking(false);
+    }
+  };
+
+  const uploadingCount = selectedImages.filter(
+    (image) => image.status === 'uploading',
+  ).length;
+  const failedCount = selectedImages.filter(
+    (image) => image.status === 'failed',
+  ).length;
+  const uploadedImages = selectedImages.flatMap((image) =>
+    image.uploaded ? [image.uploaded] : [],
+  );
+
+  const submit = async () => {
+    const text = inputText.trim();
+    if ((!text && selectedImages.length === 0) || isSubmitting) return;
+    if (uploadingCount > 0) {
+      Alert.alert('图片上传中', '请等待图片上传完成后再发布。');
+      return;
+    }
+    if (failedCount > 0 || uploadedImages.length !== selectedImages.length) {
+      Alert.alert('图片尚未准备好', '请移除上传失败的图片后重试。');
+      return;
+    }
+
+    try {
+      await onSubmit({ text, images: uploadedImages });
+      onChangeText('');
+      setSelectedImages([]);
+    } catch {
+      // The mutation owns the error toast/alert. Keep the draft for retry.
+    }
+  };
+
+  return (
+    <View
+      className="rounded-[30px] overflow-hidden"
+      style={{
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor,
+        backgroundColor:
+          colorScheme === 'dark'
+            ? 'rgba(26,26,26,0.85)'
+            : 'rgba(255,255,255,0.9)',
+      }}
+    >
+      {replyToName && (
+        <View className="flex-row justify-between items-center px-[15px] pt-2.5 pb-0.5 bg-transparent">
+          <Text type="secondary" className="text-xs">
+            正在回复 {replyToName}
+          </Text>
+          <BouncyButton
+            disabled={isSubmitting}
+            onPress={onCancelReply}
+            style={{ borderRadius: 8 }}
+          >
+            <Ionicons
+              name="close-circle"
+              size={16}
+              color={Colors[colorScheme].textSecondary}
+            />
+          </BouncyButton>
+        </View>
+      )}
+
+      {selectedImages.length > 0 && (
+        <View className="px-[15px] pt-2.5 bg-transparent">
+          <View className="flex-row flex-wrap bg-transparent">
+            {selectedImages.map((image) => (
+              <View key={image.asset.uri} className="mr-2 mb-2 bg-transparent">
+                <Image
+                  source={{ uri: image.asset.uri }}
+                  style={{ width: 48, height: 48, borderRadius: 6 }}
+                />
+                {image.status !== 'uploaded' && (
+                  <View
+                    style={{
+                      ...StyleSheet.absoluteFillObject,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      borderRadius: 6,
+                      backgroundColor: 'rgba(0,0,0,0.45)',
+                    }}
+                  >
+                    {image.status === 'uploading' ? (
+                      <ActivityIndicator size="small" color="#fff" />
+                    ) : (
+                      <Ionicons
+                        name="alert-circle"
+                        size={20}
+                        color={Colors[colorScheme].danger}
+                      />
+                    )}
+                  </View>
+                )}
+                <BouncyButton
+                  disabled={isSubmitting}
+                  onPress={() =>
+                    setSelectedImages((currentImages) =>
+                      currentImages.filter(
+                        (currentImage) =>
+                          currentImage.asset.uri !== image.asset.uri,
+                      ),
+                    )
+                  }
+                  style={{
+                    position: 'absolute',
+                    top: -6,
+                    right: -6,
+                    borderRadius: 8,
+                  }}
+                >
+                  <Ionicons
+                    name="close-circle"
+                    size={18}
+                    color={Colors[colorScheme].textSecondary}
+                  />
+                </BouncyButton>
+              </View>
+            ))}
+          </View>
+          <Text type="secondary" className="mb-1 text-xs">
+            {uploadingCount > 0
+              ? `正在上传 ${uploadingCount} 张图片...`
+              : failedCount > 0
+                ? '有图片上传失败，请移除后重新选择'
+                : `已上传 ${uploadedImages.length} 张图片`}
+          </Text>
+        </View>
+      )}
+
+      <View className="flex-row items-end px-1 py-1 bg-transparent">
+        <BouncyButton
+          disabled={isSubmitting || isPicking}
+          onPress={chooseImage}
+          style={{
+            width: 40,
+            height: 40,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: 20,
+          }}
+        >
+          {isPicking ? (
+            <ActivityIndicator size="small" color={tintColor} />
+          ) : (
+            <Ionicons name="image-outline" size={22} color={tintColor} />
+          )}
+        </BouncyButton>
+        <TextInput
+          ref={inputRef}
+          className="flex-1 min-h-[35px] max-h-[100px] px-2 pt-2.5 pb-2.5"
+          style={{ color: textColor, fontSize: 15 }}
+          placeholder={placeholder}
+          placeholderTextColor="#999"
+          value={inputText}
+          onChangeText={onChangeText}
+          multiline
+          maxLength={1000}
+        />
+        <BouncyButton
+          disabled={
+            (!inputText.trim() && selectedImages.length === 0) ||
+            isSubmitting ||
+            uploadingCount > 0 ||
+            failedCount > 0
+          }
+          onPress={submit}
+          style={{
+            height: 40,
+            justifyContent: 'center',
+            paddingHorizontal: 15,
+            borderRadius: 20,
+          }}
+        >
+          {isSubmitting ? (
+            <ActivityIndicator size="small" color={tintColor} />
+          ) : (
+            <Text
+              className="font-semibold text-base"
+              style={{
+                color: tintColor,
+                opacity:
+                  inputText.trim() || selectedImages.length > 0 ? 1 : 0.5,
+              }}
+            >
+              发布
+            </Text>
+          )}
+        </BouncyButton>
+      </View>
+    </View>
+  );
+}

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -12,6 +12,7 @@ import { voteContent } from '@/api/zhihu';
 import Colors from '@/constants/Colors';
 import { colors } from '@/constants/designTokens';
 import { showToast } from '@/utils/toast';
+import { getZhihuErrorMessage } from '@/utils/zhihuError';
 import { BouncyButton } from './BouncyButton';
 import { Text, useThemeColor } from './Themed';
 import { useColorScheme } from './useColorScheme';
@@ -85,9 +86,8 @@ export const LikeButton = ({
         onVoteChange?.(nextVoted, newCount);
       }
       showToast(isUpvoted ? '已取消赞同' : '已赞同');
-    } catch {
-      console.error('投票失败');
-      showToast('操作失败，请稍后重试');
+    } catch (error: unknown) {
+      showToast(getZhihuErrorMessage(error));
     } finally {
       setLoading(false);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "expo-file-system": "~55.0.10",
         "expo-font": "~55.0.4",
         "expo-haptics": "~55.0.8",
+        "expo-image-picker": "~55.0.8",
         "expo-intent-launcher": "~55.0.8",
         "expo-linear-gradient": "~55.0.15",
         "expo-linking": "~55.0.7",
@@ -7630,6 +7631,25 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "55.0.1",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.1.tgz",
+      "integrity": "sha512-o8gCo1j59XpXDh0/llgNYPcnfecYQhafQAO0yw5pb+kukPizvNoEqea8tFQIIQmNYqxd6Ljgs7lLXed0gXpOdQ==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "55.0.24",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.24.tgz",
+      "integrity": "sha512-scbtvQIgiqiOxQx/lFEocJkWPzYANHjwFLnzfKjdZNWh3RJjjMmtHaEoeu7lM9RzqE3EwF+JQecgy+FATXNfiQ==",
+      "dependencies": {
+        "expo-image-loader": "~55.0.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-intent-launcher": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "expo-file-system": "~55.0.10",
     "expo-font": "~55.0.4",
     "expo-haptics": "~55.0.8",
+    "expo-image-picker": "~55.0.8",
     "expo-intent-launcher": "~55.0.8",
     "expo-linear-gradient": "~55.0.15",
     "expo-linking": "~55.0.7",

--- a/utils/zhihuContent.ts
+++ b/utils/zhihuContent.ts
@@ -1,0 +1,16 @@
+import type { UploadedImage } from '@/api/zhihu/image';
+
+const IMAGE_SOURCE = '1d2f5c51';
+
+export function buildZhihuContent(text: string, imageHtml?: string): string {
+  const trimmedText = text.trim();
+  if (!imageHtml) return trimmedText;
+  return trimmedText ? `${trimmedText}<br/>${imageHtml}` : imageHtml;
+}
+
+export function buildZhihuImageHtml(image: UploadedImage): string {
+  const imageUrl = image.imageKey
+    ? `https://pic1.zhimg.com/${image.imageKey}_qhd.png?source=${IMAGE_SOURCE}`
+    : image.originalSrc || image.src;
+  return `<a class="comment_img" href="${imageUrl}" data-width="${image.width}" data-height="${image.height}">[图片]</a>`;
+}

--- a/utils/zhihuError.ts
+++ b/utils/zhihuError.ts
@@ -1,0 +1,21 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function getZhihuErrorMessage(error: unknown): string {
+  if (isRecord(error) && isRecord(error.response)) {
+    const data = error.response.data;
+    if (isRecord(data) && isRecord(data.error)) {
+      const message = data.error.message;
+      if (typeof message === 'string' && message) return message;
+    }
+    if (isRecord(data)) {
+      const message = data.message;
+      if (typeof message === 'string' && message) return message;
+    }
+  }
+
+  if (error instanceof Error && error.message) return error.message;
+
+  return '未知错误';
+}


### PR DESCRIPTION
## Summary

- Add a reusable Zhihu image upload flow with multi-image selection and upload-on-select.
- Support comment image content, v5 replies, typed comment responses, and delete actions.
- Surface Zhihu server error messages for comment likes and upload failures.
- Rename shared helpers to `zhihuContent` and `zhihuError`.

## Validation

- `npm run check`
- `git diff --check`

Native device builds and live Zhihu API verification were not run in this environment.