### PR TITLE
feat: expand Zhihu API support and search UI

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -1,9 +1,14 @@
 import CookieManager from '@preeternal/react-native-cookie-manager';
-import axios from 'axios';
+import axios, { type AxiosError, type AxiosResponse } from 'axios';
 import * as SecureStore from 'expo-secure-store';
 import { shouldImportLegacySession, useAuthStore } from '@/store/useAuthStore';
 import { useVerificationStore } from '@/store/useVerificationStore';
-import { signRequest96, ZSE_VERSION } from './zse96/index';
+import {
+  encryptZseV4,
+  hmacSha1Hex,
+  signRequest96,
+  ZSE_VERSION,
+} from './zse96/index';
 
 const apiClient = axios.create({
   baseURL: 'https://www.zhihu.com/api/v4',
@@ -16,6 +21,8 @@ const apiClient = axios.create({
 
 const requestIds = new WeakMap<object, string>();
 let requestSequence = 0;
+const retriedRequests = new WeakSet<object>();
+const refreshPromises = new Map<string, Promise<boolean>>();
 
 function getSafePath(url?: string) {
   if (!url) return '<unknown>';
@@ -46,8 +53,249 @@ function getXsrf(cookie: string) {
   return match ? match[1] : null;
 }
 
+function getHeaderValue(headers: unknown, name: string): string | undefined {
+  if (!headers || typeof headers !== 'object') return undefined;
+  const headerObject = headers as Record<string, unknown> & {
+    get?: (headerName: string) => unknown;
+  };
+  const getterValue = headerObject.get?.(name);
+  if (typeof getterValue === 'string') return getterValue;
+  if (Array.isArray(getterValue)) {
+    const values = getterValue.filter(
+      (value): value is string => typeof value === 'string',
+    );
+    if (values.length > 0) return values.join(',');
+  }
+  const directValue =
+    headerObject[name] ??
+    headerObject[name.toLowerCase()] ??
+    headerObject[name.toUpperCase()];
+  if (typeof directValue === 'string') return directValue;
+  if (Array.isArray(directValue)) {
+    const values = directValue.filter(
+      (value): value is string => typeof value === 'string',
+    );
+    if (values.length > 0) return values.join(',');
+  }
+  return undefined;
+}
+
+export function getSetCookieHeaders(headers: unknown): string[] {
+  if (!headers || typeof headers !== 'object') return [];
+  const headerObject = headers as Record<string, unknown> & {
+    get?: (headerName: string) => unknown;
+  };
+  const value =
+    headerObject.get?.('set-cookie') ??
+    headerObject['set-cookie'] ??
+    headerObject['Set-Cookie'];
+  const values = Array.isArray(value)
+    ? value.filter(
+        (item): item is string => typeof item === 'string' && item.length > 0,
+      )
+    : typeof value === 'string' && value.length > 0
+      ? [value]
+      : [];
+  return values.flatMap((item) =>
+    item.split(/,(?=\s*[^;,=\s]+=[^;]*)/).map((part) => part.trim()),
+  );
+}
+
+export function mergeCookieHeader(
+  existingCookie: string,
+  setCookieHeaders: readonly string[],
+): string {
+  const cookies = new Map<string, string>();
+  for (const assignment of existingCookie.split(';')) {
+    const separator = assignment.indexOf('=');
+    if (separator <= 0) continue;
+    const name = assignment.slice(0, separator).trim();
+    const value = assignment.slice(separator + 1).trim();
+    if (name && value) cookies.set(name, value);
+  }
+
+  for (const header of setCookieHeaders) {
+    const firstPart = header.split(';', 1)[0]?.trim();
+    if (!firstPart) continue;
+    const separator = firstPart.indexOf('=');
+    if (separator <= 0) continue;
+    const name = firstPart.slice(0, separator).trim();
+    const value = firstPart.slice(separator + 1).trim();
+    if (!name) continue;
+    if (!value) cookies.delete(name);
+    else cookies.set(name, value);
+  }
+
+  return Array.from(cookies.entries())
+    .map(([name, value]) => `${name}=${value}`)
+    .join('; ');
+}
+
+export async function buildZhihuAuthHeaders(
+  url: string,
+  cookie: string,
+  body: string | null = null,
+): Promise<Record<string, string>> {
+  if (!cookie) return {};
+  const headers: Record<string, string> = { Cookie: cookie };
+  const dc0 = getDc0(cookie);
+  const xsrf = getXsrf(cookie);
+  if (xsrf) headers['x-xsrftoken'] = xsrf;
+  if (!dc0) return headers;
+
+  headers['X-Udid'] = dc0.split('|')[0] ?? dc0;
+  const hostname = new URL(url, 'https://www.zhihu.com').hostname;
+  if (hostname !== 'zhuanlan.zhihu.com') {
+    headers['x-zse-96'] = await signRequest96(url, body, cookie);
+    headers['x-zse-93'] = ZSE_VERSION;
+  }
+  headers['x-requested-with'] = 'fetch';
+  headers.Referer =
+    hostname === 'zhuanlan.zhihu.com'
+      ? 'https://zhuanlan.zhihu.com/write'
+      : 'https://www.zhihu.com/';
+  headers['User-Agent'] =
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
+  return headers;
+}
+
 function hasAuthenticationCookie(cookie: string) {
   return /(?:^|;\s*)z_c0=/.test(cookie);
+}
+
+function getStringField(value: unknown, field: string): string | null {
+  if (!value || typeof value !== 'object') return null;
+  const fieldValue = (value as Record<string, unknown>)[field];
+  return typeof fieldValue === 'string' && fieldValue.length > 0
+    ? fieldValue
+    : null;
+}
+
+function persistResponseCookies(
+  response: AxiosResponse<unknown>,
+  requestCookie?: string,
+) {
+  const setCookieHeaders = getSetCookieHeaders(response.headers);
+  if (setCookieHeaders.length === 0) return requestCookie ?? '';
+
+  const authState = useAuthStore.getState();
+  const currentCookie = authState.cookies || '';
+  const cookieAtRequest =
+    requestCookie || getHeaderValue(response.config?.headers, 'Cookie');
+  if (cookieAtRequest && currentCookie && cookieAtRequest !== currentCookie) {
+    // A different account was selected while this request was in flight.
+    // Do not let the old response overwrite the new account's session.
+    return currentCookie;
+  }
+
+  const mergedCookie = mergeCookieHeader(
+    cookieAtRequest || currentCookie,
+    setCookieHeaders,
+  );
+  // Persist deletions too (for example `z_c0=; Max-Age=0`), otherwise a
+  // logged-out session could remain usable from the file-backed store.
+  if (mergedCookie !== currentCookie) {
+    authState.updateActiveAccountCookies(mergedCookie);
+  }
+  return mergedCookie;
+}
+
+async function performZhihuSessionRefresh(cookie: string): Promise<boolean> {
+  if (!hasAuthenticationCookie(cookie)) return false;
+  const accountIndexAtStart = useAuthStore.getState().activeAccountIndex;
+
+  const refreshClient = axios.create({
+    baseURL: 'https://www.zhihu.com',
+    timeout: 10000,
+    withCredentials: false,
+  });
+  const commonHeaders = {
+    Cookie: cookie,
+    Origin: 'https://www.zhihu.com',
+    Referer: 'https://www.zhihu.com/signin',
+    'x-requested-with': 'fetch',
+  };
+
+  try {
+    const tokenResponse = await refreshClient.post<unknown>(
+      '/api/account/prod/token/refresh',
+      undefined,
+      {
+        headers: {
+          ...commonHeaders,
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        },
+      },
+    );
+    const tokenCookie = persistResponseCookies(tokenResponse, cookie);
+    if (useAuthStore.getState().activeAccountIndex !== accountIndexAtStart) {
+      return false;
+    }
+    const refreshToken = getStringField(tokenResponse.data, 'refresh_token');
+    if (!refreshToken) return false;
+    // Account switching can happen while the first refresh request is in
+    // flight. Do not exchange the old account's token after that switch.
+    if (useAuthStore.getState().activeAccountIndex !== accountIndexAtStart) {
+      return false;
+    }
+
+    const timestamp = Date.now();
+    const formData = [
+      ['client_id', 'c3cef7c66a1843f8b3a9e6a1e3160e20'],
+      ['grant_type', 'refresh_token'],
+      ['timestamp', String(timestamp)],
+      ['source', 'com.zhihu.web'],
+      [
+        'signature',
+        hmacSha1Hex(
+          'd1b964811afb40118a12068ff74a12f4',
+          `refresh_tokenc3cef7c66a1843f8b3a9e6a1e3160e20com.zhihu.web${timestamp}`,
+        ),
+      ],
+      ['refresh_token', refreshToken],
+    ]
+      .map(
+        ([key, value]) =>
+          `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+      )
+      .join('&');
+
+    const oauthResponse = await refreshClient.post<unknown>(
+      '/api/v3/oauth/sign_in',
+      encryptZseV4(formData),
+      {
+        headers: {
+          ...commonHeaders,
+          Cookie: tokenCookie || cookie,
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+          'x-zse-83': '3_3.0',
+        },
+      },
+    );
+    if (useAuthStore.getState().activeAccountIndex !== accountIndexAtStart) {
+      return false;
+    }
+    const finalCookie = persistResponseCookies(
+      oauthResponse,
+      tokenCookie || cookie,
+    );
+    return hasAuthenticationCookie(
+      useAuthStore.getState().cookies || finalCookie || tokenCookie || cookie,
+    );
+  } catch {
+    return false;
+  }
+}
+
+function refreshZhihuSession(cookie: string): Promise<boolean> {
+  const existing = refreshPromises.get(cookie);
+  if (existing) return existing;
+
+  const promise = performZhihuSessionRefresh(cookie).finally(() => {
+    refreshPromises.delete(cookie);
+  });
+  refreshPromises.set(cookie, promise);
+  return promise;
 }
 
 apiClient.interceptors.request.use(async (config) => {
@@ -105,61 +353,69 @@ apiClient.interceptors.request.use(async (config) => {
   }
 
   if (cookie) {
-    config.headers.Cookie = cookie;
-    const dc0 = getDc0(cookie);
-    const xsrf = getXsrf(cookie);
-    if (xsrf) {
-      config.headers['x-xsrftoken'] = xsrf;
-    }
-    if (dc0) {
-      config.headers['X-Udid'] = dc0.split('|')[0]; // 添加 X-Udid 头
-      const body = config.data
-        ? typeof config.data === 'string'
-          ? config.data
-          : JSON.stringify(config.data)
-        : null;
-
-      const fullUrl = apiClient.getUri(config);
-      const hostname = new URL(fullUrl).hostname;
-      // Zhuanlan's draft editor uses its own CSRF/Origin contract and does not
-      // require the www.zhihu.com X-ZSE signature.
-      if (hostname !== 'zhuanlan.zhihu.com') {
-        const zse96 = await signRequest96(fullUrl, body, cookie);
-        config.headers['x-zse-96'] = zse96;
-        config.headers['x-zse-93'] = ZSE_VERSION;
-      }
-      config.headers['x-requested-with'] = 'fetch';
-      if (!config.headers.Referer) {
-        config.headers.Referer =
-          hostname === 'zhuanlan.zhihu.com'
-            ? 'https://zhuanlan.zhihu.com/write'
-            : 'https://www.zhihu.com/';
-      }
-      config.headers['User-Agent'] =
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
-    }
+    const body = config.data
+      ? typeof config.data === 'string'
+        ? config.data
+        : JSON.stringify(config.data)
+      : null;
+    const fullUrl = apiClient.getUri(config);
+    const configuredReferer = getHeaderValue(config.headers, 'Referer');
+    const authHeaders = await buildZhihuAuthHeaders(fullUrl, cookie, body);
+    if (configuredReferer) authHeaders.Referer = configuredReferer;
+    Object.assign(config.headers, authHeaders);
   }
   return config;
 });
 
 apiClient.interceptors.response.use(
   (response) => {
+    persistResponseCookies(response);
     const requestId = getRequestId(response.config);
     console.log(
       `✅ [API ${requestId}] ${response.config.method?.toUpperCase()} ${getSafePath(response.config.url)} Status: ${response.status}`,
     );
     return response;
   },
-  (error) => {
+  async (error: AxiosError<unknown>) => {
     const requestId = getRequestId(error.config);
     const method = error.config?.method?.toUpperCase() || '<unknown>';
     const path = getSafePath(error.config?.url);
     if (error.response?.status === 401) {
+      const requestCookie = getHeaderValue(error.config?.headers, 'Cookie');
+      if (error.config && requestCookie && !retriedRequests.has(error.config)) {
+        retriedRequests.add(error.config);
+        if (await refreshZhihuSession(requestCookie)) {
+          return apiClient.request(error.config);
+        }
+      }
+      persistResponseCookies(error.response, requestCookie);
       console.warn(`⚠️ [API ${requestId}] ${method} ${path} Status: 401`);
+    } else if (error.response) {
+      persistResponseCookies(error.response);
     }
     // 处理人机验证 40352
-    if (error.response?.data?.error?.code === 40352) {
-      const redirectUrl = error.response.data.error.redirect;
+    const responseData = error.response?.data;
+    const verificationError =
+      responseData &&
+      typeof responseData === 'object' &&
+      'error' in responseData &&
+      responseData.error &&
+      typeof responseData.error === 'object'
+        ? responseData.error
+        : null;
+    const verificationCode =
+      verificationError &&
+      'code' in verificationError &&
+      typeof verificationError.code === 'number'
+        ? verificationError.code
+        : undefined;
+    if (verificationCode === 40352) {
+      const redirectUrl =
+        verificationError &&
+        'redirect' in verificationError &&
+        typeof verificationError.redirect === 'string'
+          ? verificationError.redirect
+          : undefined;
       if (redirectUrl) {
         useVerificationStore.getState().setVerification(redirectUrl);
       }

--- a/api/session.ts
+++ b/api/session.ts
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import {
+  buildZhihuAuthHeaders,
+  getSetCookieHeaders,
+  mergeCookieHeader,
+} from './client';
+import type { ZhihuMeInfo } from './zhihu/me';
+
+const SESSION_VERIFY_INCLUDE =
+  'id,ad_type,email,account_status,is_bind_phone,available_message_types,default_notifications_count,follow_notifications_count,vote_thank_notifications_count,messages_count,is_org,avatar_url,name,url_token,draft_count,following_question_count,is_realname,is_force_renamed,renamed_fullname,is_destroy_waiting';
+
+export interface VerifiedZhihuSession {
+  cookies: string;
+  me: ZhihuMeInfo;
+}
+
+/** Verify a candidate account without changing the currently active account. */
+export async function verifyZhihuSession(
+  cookies: string,
+): Promise<VerifiedZhihuSession> {
+  if (!cookies.trim()) throw new Error('登录 Cookie 为空');
+  const url = `https://www.zhihu.com/api/v4/me?include=${SESSION_VERIFY_INCLUDE}`;
+  const response = await axios.get<ZhihuMeInfo>(url, {
+    timeout: 10000,
+    withCredentials: false,
+    headers: await buildZhihuAuthHeaders(url, cookies),
+  });
+  const mergedCookies = mergeCookieHeader(
+    cookies,
+    getSetCookieHeaders(response.headers),
+  );
+  return { cookies: mergedCookies || cookies, me: response.data };
+}

--- a/api/zhihu/answer.ts
+++ b/api/zhihu/answer.ts
@@ -23,6 +23,7 @@ export interface AnswerDetail {
   question?: AnswerQuestion;
   author: ZhihuAuthor;
   content: string;
+  editable_content?: string;
   excerpt: string;
   created_time: number;
   created_time_name?: string;
@@ -182,7 +183,7 @@ export const getAnswer = async (
   include?: string,
 ): Promise<AnswerDetail> => {
   const defaultInclude =
-    'content,paid_info,can_comment,excerpt,thanks_count,voteup_count,comment_count,visited_count,reaction,ip_info,question.topics,author.is_following,reaction.relation.voting,segment_infos,favlists_count';
+    'content,editable_content,paid_info,can_comment,excerpt,thanks_count,voteup_count,comment_count,visited_count,reaction,ip_info,question.topics,author.is_following,reaction.relation.voting,segment_infos,favlists_count';
   const res = await apiClient.get(
     `/answers/${id}?include=${include || defaultInclude}`,
   );
@@ -269,7 +270,7 @@ export async function publishAnswer(
           }
         : { isPublished: false, disabled: 1 },
       extra_info: {
-        ...(!isPublished && { question_id: questionIdString }),
+        question_id: questionIdString,
         publisher: 'pc',
         include: ANSWER_PUBLISH_INCLUDE,
         pc_business_params: businessParams,

--- a/api/zhihu/pin.ts
+++ b/api/zhihu/pin.ts
@@ -39,8 +39,18 @@ interface PinContentData {
 
 export const getPin = async (id: string | number) => {
   const include =
-    'author,author.is_following,content,content_html,created,like_count,comment_count,relationship.voting';
+    'author,author.is_following,content,content_html,created,like_count,comment_count,relationship.voting,topics';
   const res = await client.get(`/pins/${id}?include=${include}`);
+  return res.data;
+};
+
+export const votePinPoll = async (
+  pollId: string | number,
+  optionIds: Array<string | number>,
+) => {
+  const res = await client.post(`/polls/${pollId}`, {
+    options: optionIds.map(String),
+  });
   return res.data;
 };
 

--- a/api/zhihu/question.ts
+++ b/api/zhihu/question.ts
@@ -27,7 +27,7 @@ export interface ZhihuQuestionDetail extends ZhihuQuestion {
 }
 
 export const QUESTION_INCLUDE =
-  'detail,excerpt,answer_count,comment_count,follower_count,visit_count,topics,relationship.is_following,relationship.is_author,relationship.is_anonymous,relationship.voting,relationship.is_thanked,relationship.is_nothelp';
+  'detail,excerpt,answer_count,comment_count,follower_count,visit_count,topics,relationship.is_following,relationship.is_author,relationship.is_anonymous,relationship.voting,relationship.is_thanked,relationship.is_nothelp,relationship.my_answer';
 
 export const getQuestion = async (
   id: string | number,

--- a/api/zhihu/search.ts
+++ b/api/zhihu/search.ts
@@ -17,6 +17,15 @@ export const searchContent = async (
     restricted_scene?: string;
     restricted_field?: string;
     restricted_value?: string;
+    vertical?: 'answer' | 'article' | 'zvideo';
+    sort?: 'created_time' | 'upvoted_count';
+    time_interval?:
+      | 'a_day'
+      | 'a_week'
+      | 'a_month'
+      | 'three_months'
+      | 'half_a_year'
+      | 'a_year';
   },
 ): Promise<ZhihuSearchResponse> => {
   const params = new URLSearchParams({
@@ -30,6 +39,19 @@ export const searchContent = async (
     show_all_topics: '0',
     search_source: 'Normal',
   });
+  if (options?.vertical) {
+    params.set('vertical', options.vertical);
+    params.set('vertical_info', '0,0,0,0,0,0,0,0,0,0,0,0');
+    params.set('search_source', 'Filter');
+  }
+  if (options?.sort) {
+    params.set('sort', options.sort);
+    params.set('search_source', 'Filter');
+  }
+  if (options?.time_interval) {
+    params.set('time_interval', options.time_interval);
+    params.set('search_source', 'Filter');
+  }
   if (options?.restricted_scene)
     params.append('restricted_scene', options.restricted_scene);
   if (options?.restricted_field)

--- a/api/zhihu/voters.ts
+++ b/api/zhihu/voters.ts
@@ -16,6 +16,45 @@ export interface ZhihuVoteResponse {
   [key: string]: unknown;
 }
 
+export interface ZhihuVoter {
+  id: string;
+  url_token?: string;
+  name: string;
+  avatar_url?: string;
+  headline?: string;
+  is_following?: boolean;
+}
+
+export interface ZhihuVotersResponse {
+  data: ZhihuVoter[];
+  paging?: {
+    is_end?: boolean;
+    next?: string;
+  };
+}
+
+export const getAnswerVoters = async (
+  id: string | number,
+  limit = 20,
+  offset = 0,
+): Promise<ZhihuVotersResponse> => {
+  const res = await apiClient.get<ZhihuVotersResponse>(
+    `/answers/${id}/upvoters?limit=${limit}&offset=${offset}`,
+  );
+  return res.data;
+};
+
+export const getPinVoters = async (
+  id: string | number,
+  limit = 20,
+  offset = 0,
+): Promise<ZhihuVotersResponse> => {
+  const res = await apiClient.get<ZhihuVotersResponse>(
+    `/pins/${id}/upvoters?limit=${limit}&offset=${offset}`,
+  );
+  return res.data;
+};
+
 export const voteContent = async (
   id: string | number,
   type: 'answers' | 'articles' | 'questions' | 'pins' | 'comments',

--- a/api/zse96/hmac.ts
+++ b/api/zse96/hmac.ts
@@ -1,0 +1,154 @@
+function rotateLeft(value: number, bits: number): number {
+  return (value << bits) | (value >>> (32 - bits));
+}
+
+function encodeUtf8(value: string): Uint8Array {
+  const bytes: number[] = [];
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint <= 0x7f) {
+      bytes.push(codePoint);
+    } else if (codePoint <= 0x7ff) {
+      bytes.push(0xc0 | (codePoint >> 6), 0x80 | (codePoint & 0x3f));
+    } else if (codePoint <= 0xffff) {
+      bytes.push(
+        0xe0 | (codePoint >> 12),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f),
+      );
+    } else {
+      bytes.push(
+        0xf0 | (codePoint >> 18),
+        0x80 | ((codePoint >> 12) & 0x3f),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f),
+      );
+    }
+  }
+  return new Uint8Array(bytes);
+}
+
+function concatBytes(...chunks: Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+function sha1(input: Uint8Array): Uint8Array {
+  const bitLength = input.length * 8;
+  const paddedLength = Math.ceil((input.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(input);
+  padded[input.length] = 0x80;
+  const lengthOffset = padded.length - 8;
+  const high = Math.floor(bitLength / 0x100000000);
+  const low = bitLength >>> 0;
+  padded[lengthOffset] = (high >>> 24) & 0xff;
+  padded[lengthOffset + 1] = (high >>> 16) & 0xff;
+  padded[lengthOffset + 2] = (high >>> 8) & 0xff;
+  padded[lengthOffset + 3] = high & 0xff;
+  padded[lengthOffset + 4] = (low >>> 24) & 0xff;
+  padded[lengthOffset + 5] = (low >>> 16) & 0xff;
+  padded[lengthOffset + 6] = (low >>> 8) & 0xff;
+  padded[lengthOffset + 7] = low & 0xff;
+
+  let h0 = 0x67452301;
+  let h1 = 0xefcdab89;
+  let h2 = 0x98badcfe;
+  let h3 = 0x10325476;
+  let h4 = 0xc3d2e1f0;
+
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    const words = new Uint32Array(80);
+    for (let index = 0; index < 16; index += 1) {
+      const position = offset + index * 4;
+      words[index] =
+        (padded[position] << 24) |
+        (padded[position + 1] << 16) |
+        (padded[position + 2] << 8) |
+        padded[position + 3];
+    }
+    for (let index = 16; index < 80; index += 1) {
+      words[index] = rotateLeft(
+        words[index - 3] ^
+          words[index - 8] ^
+          words[index - 14] ^
+          words[index - 16],
+        1,
+      );
+    }
+
+    let a = h0;
+    let b = h1;
+    let c = h2;
+    let d = h3;
+    let e = h4;
+    for (let index = 0; index < 80; index += 1) {
+      let functionValue: number;
+      let constant: number;
+      if (index < 20) {
+        functionValue = (b & c) | (~b & d);
+        constant = 0x5a827999;
+      } else if (index < 40) {
+        functionValue = b ^ c ^ d;
+        constant = 0x6ed9eba1;
+      } else if (index < 60) {
+        functionValue = (b & c) | (b & d) | (c & d);
+        constant = 0x8f1bbcdc;
+      } else {
+        functionValue = b ^ c ^ d;
+        constant = 0xca62c1d6;
+      }
+      const next =
+        (rotateLeft(a, 5) + functionValue + e + constant + words[index]) | 0;
+      e = d;
+      d = c;
+      c = rotateLeft(b, 30);
+      b = a;
+      a = next;
+    }
+    h0 = (h0 + a) | 0;
+    h1 = (h1 + b) | 0;
+    h2 = (h2 + c) | 0;
+    h3 = (h3 + d) | 0;
+    h4 = (h4 + e) | 0;
+  }
+
+  const result = new Uint8Array(20);
+  const words = [h0, h1, h2, h3, h4];
+  words.forEach((word, index) => {
+    const offset = index * 4;
+    result[offset] = (word >>> 24) & 0xff;
+    result[offset + 1] = (word >>> 16) & 0xff;
+    result[offset + 2] = (word >>> 8) & 0xff;
+    result[offset + 3] = word & 0xff;
+  });
+  return result;
+}
+
+export function hmacSha1Hex(key: string, message: string): string {
+  const blockSize = 64;
+  let keyBytes = encodeUtf8(key);
+  if (keyBytes.length > blockSize) keyBytes = sha1(keyBytes);
+
+  const paddedKey = new Uint8Array(blockSize);
+  paddedKey.set(keyBytes);
+  const innerPad = new Uint8Array(blockSize);
+  const outerPad = new Uint8Array(blockSize);
+  for (let index = 0; index < blockSize; index += 1) {
+    innerPad[index] = paddedKey[index] ^ 0x36;
+    outerPad[index] = paddedKey[index] ^ 0x5c;
+  }
+
+  const digest = sha1(
+    concatBytes(outerPad, sha1(concatBytes(innerPad, encodeUtf8(message)))),
+  );
+  return Array.from(digest, (byte) => byte.toString(16).padStart(2, '0')).join(
+    '',
+  );
+}

--- a/api/zse96/index.ts
+++ b/api/zse96/index.ts
@@ -1,5 +1,8 @@
 import { getSignaturePurity } from './zse_purity';
 
+export { hmacSha1Hex } from './hmac';
+export { encryptZseV4 } from './zse_purity';
+
 export const ZSE_VERSION = '101_3_3.0';
 
 /**

--- a/api/zse96/zse_purity.ts
+++ b/api/zse96/zse_purity.ts
@@ -90,6 +90,64 @@ const customEncode = (bytes: Uint8Array) => {
   return out;
 };
 
+function encodeUtf8(value: string): Uint8Array {
+  const bytes: number[] = [];
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint <= 0x7f) {
+      bytes.push(codePoint);
+    } else if (codePoint <= 0x7ff) {
+      bytes.push(0xc0 | (codePoint >> 6), 0x80 | (codePoint & 0x3f));
+    } else if (codePoint <= 0xffff) {
+      bytes.push(
+        0xe0 | (codePoint >> 12),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f),
+      );
+    } else {
+      bytes.push(
+        0xf0 | (codePoint >> 18),
+        0x80 | ((codePoint >> 12) & 0x3f),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f),
+      );
+    }
+  }
+  return new Uint8Array(bytes);
+}
+
+/** Encrypt the x-zse-83 form payload used by Zhihu's web token refresh flow. */
+export const encryptZseV4 = (input: string): string => {
+  const inputBytes = encodeUtf8(input);
+  const plain = new Uint8Array(2 + inputBytes.length);
+  plain[0] = 210;
+  plain.set(inputBytes, 2);
+
+  const pad = 16 - (plain.length % 16);
+  const padded = new Uint8Array(plain.length + pad);
+  padded.set(plain);
+  padded.fill(pad, plain.length);
+
+  const cipher = new Uint8Array(padded.length);
+  const firstBlock = new Uint8Array(16);
+  for (let index = 0; index < 16; index += 1) {
+    firstBlock[index] = padded[index] ^ KEY16[index] ^ 42;
+  }
+
+  let previous = encryptBlock(firstBlock);
+  cipher.set(previous, 0);
+  for (let offset = 16; offset < padded.length; offset += 16) {
+    const block = new Uint8Array(16);
+    for (let index = 0; index < 16; index += 1) {
+      block[index] = padded[offset + index] ^ previous[index];
+    }
+    previous = encryptBlock(block);
+    cipher.set(previous, offset);
+  }
+
+  return customEncode(cipher);
+};
+
 /**
  * 生成知乎 x-zse-96 签名 (2.0版本) - 移植自 zhi-purity
  * @param path 请求路径 (如 /api/v4/me?include=is_realname)

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -11,6 +11,7 @@ import {
   ScrollView,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { verifyZhihuSession } from '@/api/session';
 import { getMe, getMemberWithFallback } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
 import { BottomSheet } from '@/components/overlays/BottomSheet';
@@ -187,10 +188,24 @@ export default function ProfileScreen({ isActive = true }: ProfileScreenProps) {
       return;
     }
 
-    switchAccount(index);
+    let verifiedSession:
+      | Awaited<ReturnType<typeof verifyZhihuSession>>
+      | undefined;
+    if (index !== -1) {
+      try {
+        verifiedSession = await verifyZhihuSession(targetCookies ?? '');
+      } catch {
+        Alert.alert('切换失败', '目标账号的登录信息已失效，请重新登录。');
+        sessionChangeInFlight.current = false;
+        setSessionChanging(false);
+        return;
+      }
+    }
+
+    switchAccount(index, verifiedSession);
     queryClient.clear();
     setAccountModalVisible(false);
-    await syncSessionWithFeedback(targetCookies);
+    await syncSessionWithFeedback(verifiedSession?.cookies ?? targetCookies);
     sessionChangeInFlight.current = false;
     setSessionChanging(false);
   };

--- a/app/pin/[id].tsx
+++ b/app/pin/[id].tsx
@@ -1,23 +1,30 @@
 import { Ionicons } from '@expo/vector-icons';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { BlurView } from 'expo-blur';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect } from 'react';
-import { ActivityIndicator, Image, ScrollView, StyleSheet } from 'react-native';
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { addReadHistory } from '@/api/zhihu/history';
 import { followMember, unfollowMember } from '@/api/zhihu/member';
-import { getPin } from '@/api/zhihu/pin';
+import { getPin, votePinPoll } from '@/api/zhihu/pin';
 import { BouncyButton } from '@/components/BouncyButton';
 import { LikeButton } from '@/components/LikeButton';
 import { ShareMenu } from '@/components/ShareMenu';
 import { Text, ThemedIcon, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
+import { VoterListModal } from '@/components/VoterListModal';
 import Colors from '@/constants/Colors';
 import { ZhihuContent } from '@/features/rich-content';
 import { useOptimisticToggle } from '@/hooks/useOptimisticToggle';
 import { useSettingsStore } from '@/store/useSettingsStore';
-import type { ZhihuPin } from '@/types/zhihu';
+import type { ZhihuPin, ZhihuPinPoll } from '@/types/zhihu';
 import { formatDateTime } from '@/utils/date';
 
 export default function PinDetailScreen() {
@@ -25,7 +32,7 @@ export default function PinDetailScreen() {
   const { id } = useLocalSearchParams();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const _queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   const textColor = Colors[colorScheme].text;
   const borderColor = Colors[colorScheme].border;
   const backgroundColor = Colors[colorScheme].background;
@@ -34,6 +41,10 @@ export default function PinDetailScreen() {
   const primaryTransparent = useThemeColor({}, 'primaryTransparent');
 
   const [isSharing, setIsSharing] = React.useState(false);
+  const [votersVisible, setVotersVisible] = React.useState(false);
+  const [pollVotingOptionId, setPollVotingOptionId] = React.useState<
+    string | null
+  >(null);
 
   const {
     data: pin,
@@ -44,6 +55,21 @@ export default function PinDetailScreen() {
     queryFn: () => getPin(id as string),
     retry: (failureCount, err: any) =>
       err?.response?.status === 404 ? false : failureCount < 2,
+  });
+
+  const poll = pin?.bottom_poll?.voting as ZhihuPinPoll | undefined;
+  const pollMutation = useMutation({
+    mutationFn: ({ pollId, optionId }: { pollId: string; optionId: string }) =>
+      votePinPoll(pollId, [optionId]),
+    onMutate: ({ optionId }) => setPollVotingOptionId(optionId),
+    onSuccess: async () => {
+      setPollVotingOptionId(null);
+      await queryClient.invalidateQueries({ queryKey: ['pin-detail', id] });
+    },
+    onError: () => {
+      setPollVotingOptionId(null);
+      Alert.alert('投票失败', '知乎没有接受这次投票，请稍后重试。');
+    },
   });
 
   const enableBrowseHistory = useSettingsStore((s) => s.enableBrowseHistory);
@@ -212,6 +238,15 @@ export default function PinDetailScreen() {
             type="pin"
             onRefresh={refetch}
           />
+          {poll ? (
+            <PinPollCard
+              poll={poll}
+              votingOptionId={pollVotingOptionId}
+              onVote={(pollId, optionId) =>
+                pollMutation.mutate({ pollId, optionId })
+              }
+            />
+          ) : null}
           <Text
             type="secondary"
             className="text-[#bbb] text-[13px] mt-[30px] italic pb-5"
@@ -282,6 +317,113 @@ export default function PinDetailScreen() {
           </View>
         </BlurView>
       </View>
+
+      <VoterListModal
+        visible={votersVisible}
+        onClose={() => setVotersVisible(false)}
+        contentType="pin"
+        contentId={String(id)}
+        count={pin?.like_count}
+      />
+    </View>
+  );
+}
+
+function PinPollCard({
+  poll,
+  votingOptionId,
+  onVote,
+}: {
+  poll: ZhihuPinPoll;
+  votingOptionId: string | null;
+  onVote: (pollId: string, optionId: string) => void;
+}) {
+  const colorScheme = useColorScheme();
+  const primaryColor = useThemeColor({}, 'primary');
+  const borderColor = Colors[colorScheme].border;
+  const now = Math.floor(Date.now() / 1000);
+  const acceptsVote =
+    poll.is_reviewing !== true &&
+    (poll.end_at === undefined || poll.end_at < 0 || poll.end_at > now);
+  const resultMode = poll.is_voted === true || !acceptsVote;
+  const totalVotes = poll.member_count || poll.voting_count || 0;
+
+  return (
+    <View
+      className="mt-4 rounded-2xl p-4"
+      style={{
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor,
+        backgroundColor: Colors[colorScheme].backgroundSecondary,
+      }}
+    >
+      <Text className="font-bold text-base">{poll.title || '想法投票'}</Text>
+      <Text type="secondary" className="text-xs mt-1 mb-3">
+        {resultMode
+          ? poll.is_reviewing
+            ? '投票审核中'
+            : poll.end_at !== undefined && poll.end_at <= now
+              ? `投票已结束 · ${totalVotes} 人参与`
+              : `${totalVotes} 人参与`
+          : poll.max_selections && poll.max_selections > 1
+            ? `最多选择 ${poll.max_selections} 项`
+            : '请选择一个选项'}
+      </Text>
+      {poll.options.map((option) => {
+        const optionVotes = option.voting_count || 0;
+        const percentage =
+          totalVotes > 0 ? Math.round((optionVotes / totalVotes) * 100) : 0;
+        if (resultMode) {
+          return (
+            <View key={option.id} className="mb-2">
+              <View className="flex-row justify-between mb-1">
+                <Text className="text-sm flex-1" numberOfLines={1}>
+                  {option.title}
+                </Text>
+                <Text type="secondary" className="text-xs ml-2">
+                  {percentage}%
+                </Text>
+              </View>
+              <View
+                className="h-2 rounded-full overflow-hidden"
+                style={{ backgroundColor: borderColor }}
+              >
+                <View
+                  className="h-full rounded-full"
+                  style={{
+                    width: `${percentage}%`,
+                    backgroundColor: option.is_selected
+                      ? primaryColor
+                      : Colors[colorScheme].textSecondary,
+                  }}
+                />
+              </View>
+            </View>
+          );
+        }
+
+        return (
+          <BouncyButton
+            key={option.id}
+            disabled={votingOptionId !== null}
+            onPress={() => onVote(poll.id, option.id)}
+            className="rounded-xl px-3 py-2.5 mb-2"
+            style={{
+              borderWidth: StyleSheet.hairlineWidth,
+              borderColor: primaryColor,
+              opacity: votingOptionId === option.id ? 0.6 : 1,
+            }}
+          >
+            {votingOptionId === option.id ? (
+              <ActivityIndicator size="small" color={primaryColor} />
+            ) : (
+              <Text style={{ color: primaryColor }} className="text-sm">
+                {option.title}
+              </Text>
+            )}
+          </BouncyButton>
+        );
+      })}
     </View>
   );
 }

--- a/app/question/write/[id].tsx
+++ b/app/question/write/[id].tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -9,11 +9,17 @@ import {
   ScrollView,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { createAnswer, getQuestion } from '@/api/zhihu';
+import {
+  createAnswer,
+  getAnswer,
+  getQuestion,
+  updateAnswer,
+} from '@/api/zhihu';
 import type { UploadedImage } from '@/api/zhihu/image';
 import { BouncyButton } from '@/components/BouncyButton';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import {
+  deserializePublishingHtml,
   PublishingEditor,
   serializePublishingMarkdown,
 } from '@/features/publishing';
@@ -28,25 +34,65 @@ export default function WriteAnswerScreen() {
   const [content, setContent] = useState('');
   const [uploadedImages, setUploadedImages] = useState<UploadedImage[]>([]);
   const [editorBusy, setEditorBusy] = useState(false);
+  const initializedAnswerId = useRef<string | null>(null);
 
   const { data: question, isLoading: qLoading } = useQuery({
     queryKey: ['question', id],
     queryFn: () => getQuestion(id as string),
   });
 
+  const existingAnswerId = (() => {
+    const myAnswer = question?.relationship?.my_answer;
+    if (!myAnswer || myAnswer.is_deleted) return undefined;
+    const answerId = myAnswer.id ?? myAnswer.answer_id;
+    return answerId === undefined ? undefined : String(answerId);
+  })();
+
+  const { data: existingAnswer, isLoading: answerLoading } = useQuery({
+    queryKey: ['answer-edit', existingAnswerId],
+    queryFn: () => getAnswer(existingAnswerId as string),
+    enabled: !!existingAnswerId,
+  });
+
+  useEffect(() => {
+    if (!existingAnswerId) {
+      initializedAnswerId.current = null;
+      return;
+    }
+    if (!existingAnswer || initializedAnswerId.current === existingAnswerId) {
+      return;
+    }
+    const editableContent =
+      existingAnswer.editable_content || existingAnswer.content || '';
+    setContent(deserializePublishingHtml(editableContent));
+    initializedAnswerId.current = existingAnswerId;
+  }, [existingAnswer, existingAnswerId]);
+
   const mutation = useMutation({
-    mutationFn: () =>
-      createAnswer(
-        id as string,
-        serializePublishingMarkdown(content, uploadedImages),
-      ),
+    mutationFn: () => {
+      const html = serializePublishingMarkdown(content, uploadedImages);
+      return existingAnswerId
+        ? updateAnswer(id as string, existingAnswerId, html)
+        : createAnswer(id as string, html);
+    },
     onSuccess: () => {
-      Alert.alert('发布成功', '你的回答已发布喵！');
+      Alert.alert(
+        existingAnswerId ? '保存成功' : '发布成功',
+        existingAnswerId ? '你的回答修改已保存喵！' : '你的回答已发布喵！',
+      );
       queryClient.invalidateQueries({ queryKey: ['question-answers', id] });
+      if (existingAnswerId) {
+        queryClient.invalidateQueries({
+          queryKey: ['answer-detail', existingAnswerId],
+        });
+      }
       router.back();
     },
     onError: (error: unknown) =>
-      Alert.alert('发布失败', getZhihuErrorMessage(error)),
+      Alert.alert(
+        existingAnswerId ? '保存失败' : '发布失败',
+        getZhihuErrorMessage(error),
+      ),
   });
 
   const handlePublish = () => {
@@ -61,7 +107,7 @@ export default function WriteAnswerScreen() {
     mutation.mutate();
   };
 
-  if (qLoading) {
+  if (qLoading || answerLoading) {
     return (
       <View className="flex-1 justify-center items-center">
         <ActivityIndicator size="large" color={primaryColor} />
@@ -73,7 +119,7 @@ export default function WriteAnswerScreen() {
     <View className="flex-1">
       <Stack.Screen
         options={{
-          headerTitle: '写回答',
+          headerTitle: existingAnswerId ? '编辑回答' : '写回答',
           headerRight: () => (
             <BouncyButton
               className="px-3 py-2 rounded-full"
@@ -88,7 +134,7 @@ export default function WriteAnswerScreen() {
                   className="text-base font-bold mr-[15px]"
                   style={{ color: primaryColor }}
                 >
-                  发布
+                  {existingAnswerId ? '保存' : '发布'}
                 </Text>
               )}
             </BouncyButton>

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -14,6 +14,7 @@ import {
 import { getSearchSuggest, searchContent } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
 import { FeedCard } from '@/components/FeedCard';
+import { BottomSheet } from '@/components/overlays/BottomSheet';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { UserCard } from '@/components/UserCard';
 import { useColorScheme } from '@/components/useColorScheme';
@@ -25,6 +26,29 @@ function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+const SEARCH_CONTENT_FILTERS = [
+  { label: '全部', value: undefined },
+  { label: '回答', value: 'answer' as const },
+  { label: '文章', value: 'article' as const },
+  { label: '视频', value: 'zvideo' as const },
+];
+
+const SEARCH_SORT_FILTERS = [
+  { label: '综合', value: undefined },
+  { label: '最新发布', value: 'created_time' as const },
+  { label: '最多赞同', value: 'upvoted_count' as const },
+];
+
+const SEARCH_TIME_FILTERS = [
+  { label: '不限时间', value: undefined },
+  { label: '一天内', value: 'a_day' as const },
+  { label: '一周内', value: 'a_week' as const },
+  { label: '一个月内', value: 'a_month' as const },
+  { label: '三个月内', value: 'three_months' as const },
+  { label: '半年内', value: 'half_a_year' as const },
+  { label: '一年内', value: 'a_year' as const },
+];
+
 export default function SearchScreen() {
   const colorScheme = useColorScheme();
   const router = useRouter();
@@ -33,7 +57,23 @@ export default function SearchScreen() {
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [searchType, setSearchType] = useState('general');
+  const [contentFilter, setContentFilter] = useState<
+    'answer' | 'article' | 'zvideo' | undefined
+  >();
+  const [sortFilter, setSortFilter] = useState<
+    'created_time' | 'upvoted_count' | undefined
+  >();
+  const [timeFilter, setTimeFilter] = useState<
+    | 'a_day'
+    | 'a_week'
+    | 'a_month'
+    | 'three_months'
+    | 'half_a_year'
+    | 'a_year'
+    | undefined
+  >();
   const [isSearching, setIsSearching] = useState(false);
+  const [filterSheetVisible, setFilterSheetVisible] = useState(false);
 
   const { history, addHistory, clearHistory, removeHistory } = useSearchStore();
 
@@ -42,6 +82,31 @@ export default function SearchScreen() {
   const surfaceColor = Colors[colorScheme].backgroundTertiary;
   const textColor = useThemeColor({}, 'text');
   const borderColor = useThemeColor({}, 'border');
+
+  const activeFilterCount =
+    Number(contentFilter !== undefined) +
+    Number(sortFilter !== undefined) +
+    Number(timeFilter !== undefined);
+
+  const activeFilterLabels = [
+    contentFilter
+      ? `类型：${SEARCH_CONTENT_FILTERS.find((item) => item.value === contentFilter)?.label}`
+      : null,
+    sortFilter
+      ? `排序：${SEARCH_SORT_FILTERS.find((item) => item.value === sortFilter)?.label}`
+      : null,
+    timeFilter
+      ? `时间：${SEARCH_TIME_FILTERS.find((item) => item.value === timeFilter)?.label}`
+      : null,
+  ].filter((label): label is string => Boolean(label));
+  const emptyStateIcon =
+    activeFilterCount > 0 ? 'options-outline' : 'search-outline';
+
+  const clearFilters = () => {
+    setContentFilter(undefined);
+    setSortFilter(undefined);
+    setTimeFilter(undefined);
+  };
 
   useEffect(() => {
     const handler = setTimeout(() => setDebouncedQuery(query), 300);
@@ -61,9 +126,20 @@ export default function SearchScreen() {
     isFetchingNextPage,
     isLoading,
   } = useInfiniteQuery({
-    queryKey: ['search-results', debouncedQuery, searchType],
+    queryKey: [
+      'search-results',
+      debouncedQuery,
+      searchType,
+      contentFilter,
+      sortFilter,
+      timeFilter,
+    ],
     queryFn: ({ pageParam = 0 }) =>
-      searchContent(debouncedQuery, pageParam as number, 20, searchType),
+      searchContent(debouncedQuery, pageParam as number, 20, searchType, {
+        vertical: searchType === 'general' ? contentFilter : undefined,
+        sort: searchType === 'general' ? sortFilter : undefined,
+        time_interval: searchType === 'general' ? timeFilter : undefined,
+      }),
     enabled: isSearching && debouncedQuery.length > 0,
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
@@ -244,6 +320,55 @@ export default function SearchScreen() {
     </View>
   );
 
+  const FilterRow = ({
+    title,
+    options,
+    selected,
+    onSelect,
+  }: {
+    title: string;
+    options: ReadonlyArray<{ label: string; value: string | undefined }>;
+    selected: string | undefined;
+    onSelect: (value: string | undefined) => void;
+  }) => (
+    <View className="flex-row items-center mb-2">
+      <Text type="secondary" className="w-[58px] text-xs">
+        {title}
+      </Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ paddingRight: 15 }}
+      >
+        {options.map((option) => {
+          const active = option.value === selected;
+          return (
+            <BouncyButton
+              key={option.value ?? 'all'}
+              onPress={() => onSelect(option.value)}
+              className="mr-2 px-3 py-1 rounded-full"
+              style={{
+                backgroundColor: active
+                  ? Colors[colorScheme].primaryTransparent
+                  : surfaceColor,
+              }}
+            >
+              <Text
+                className="text-xs"
+                style={{
+                  color: active ? tintColor : textColor,
+                  fontWeight: active ? '600' : '400',
+                }}
+              >
+                {option.label}
+              </Text>
+            </BouncyButton>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+
   return (
     <View className="flex-1">
       <Stack.Screen options={{ headerShown: false }} />
@@ -317,6 +442,182 @@ export default function SearchScreen() {
 
       {isSearching && <SearchTabs />}
 
+      {isSearching && searchType === 'general' && (
+        <View
+          className="flex-row items-center px-[15px] py-2"
+          style={{
+            backgroundColor,
+            borderBottomWidth: StyleSheet.hairlineWidth,
+            borderBottomColor: borderColor,
+          }}
+        >
+          <BouncyButton
+            className="flex-row items-center px-3 py-1.5 rounded-full"
+            style={{ backgroundColor: surfaceColor }}
+            onPress={() => setFilterSheetVisible(true)}
+          >
+            <Ionicons
+              name="options-outline"
+              size={15}
+              color={activeFilterCount > 0 ? tintColor : textColor}
+            />
+            <Text
+              className="ml-1.5 text-xs"
+              style={{
+                color: activeFilterCount > 0 ? tintColor : textColor,
+                fontWeight: '600',
+              }}
+            >
+              筛选
+            </Text>
+            {activeFilterCount > 0 ? (
+              <View
+                className="ml-1.5 min-w-[17px] h-[17px] rounded-full items-center justify-center"
+                style={{ backgroundColor: tintColor }}
+              >
+                <Text className="text-[10px] text-white font-bold">
+                  {activeFilterCount}
+                </Text>
+              </View>
+            ) : null}
+          </BouncyButton>
+
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            className="flex-1 ml-2"
+            contentContainerStyle={{ paddingRight: 4 }}
+          >
+            {activeFilterLabels.length > 0 ? (
+              activeFilterLabels.map((label) => (
+                <BouncyButton
+                  key={label}
+                  className="flex-row items-center px-2.5 py-1 rounded-full mr-1.5"
+                  style={{
+                    backgroundColor: Colors[colorScheme].primaryTransparent,
+                  }}
+                  onPress={() => setFilterSheetVisible(true)}
+                >
+                  <Text
+                    className="text-xs"
+                    style={{ color: tintColor }}
+                    numberOfLines={1}
+                  >
+                    {label}
+                  </Text>
+                  <Ionicons
+                    name="chevron-down"
+                    size={12}
+                    color={tintColor}
+                    style={{ marginLeft: 3 }}
+                  />
+                </BouncyButton>
+              ))
+            ) : (
+              <Text type="tertiary" className="text-xs ml-1 py-1">
+                综合结果
+              </Text>
+            )}
+          </ScrollView>
+
+          {activeFilterCount > 0 ? (
+            <BouncyButton className="ml-1 px-1" onPress={clearFilters}>
+              <Text type="secondary" className="text-xs">
+                重置
+              </Text>
+            </BouncyButton>
+          ) : null}
+        </View>
+      )}
+
+      <BottomSheet
+        visible={filterSheetVisible}
+        onClose={() => setFilterSheetVisible(false)}
+        title="筛选搜索结果"
+        subtitle={
+          activeFilterCount > 0
+            ? `已选择 ${activeFilterCount} 项`
+            : '按你的阅读目标调整结果'
+        }
+        height="58%"
+      >
+        <ScrollView
+          contentContainerStyle={{ paddingHorizontal: 15, paddingVertical: 12 }}
+          showsVerticalScrollIndicator={false}
+        >
+          <FilterRow
+            title="类型"
+            options={SEARCH_CONTENT_FILTERS}
+            selected={contentFilter}
+            onSelect={(value) =>
+              setContentFilter(
+                value as 'answer' | 'article' | 'zvideo' | undefined,
+              )
+            }
+          />
+          <FilterRow
+            title="排序"
+            options={SEARCH_SORT_FILTERS}
+            selected={sortFilter}
+            onSelect={(value) =>
+              setSortFilter(
+                value as 'created_time' | 'upvoted_count' | undefined,
+              )
+            }
+          />
+          <FilterRow
+            title="时间"
+            options={SEARCH_TIME_FILTERS}
+            selected={timeFilter}
+            onSelect={(value) =>
+              setTimeFilter(
+                value as
+                  | 'a_day'
+                  | 'a_week'
+                  | 'a_month'
+                  | 'three_months'
+                  | 'half_a_year'
+                  | 'a_year'
+                  | undefined,
+              )
+            }
+          />
+          <View className="flex-row items-center mt-3">
+            <BouncyButton
+              className="flex-1 items-center py-2.5 rounded-xl mr-2"
+              style={{ backgroundColor: surfaceColor }}
+              onPress={clearFilters}
+            >
+              <Text type="secondary" className="text-sm font-semibold">
+                清除条件
+              </Text>
+            </BouncyButton>
+            <BouncyButton
+              className="flex-1 items-center py-2.5 rounded-xl"
+              style={{ backgroundColor: tintColor }}
+              onPress={() => setFilterSheetVisible(false)}
+            >
+              <Text className="text-sm font-semibold text-white">完成</Text>
+            </BouncyButton>
+          </View>
+        </ScrollView>
+      </BottomSheet>
+
+      {isSearching && flattenedResults.length > 0 ? (
+        <View
+          className="flex-row items-center px-[15px] py-2"
+          style={{ backgroundColor }}
+        >
+          <Text type="secondary" className="text-xs">
+            “{debouncedQuery}”的结果
+          </Text>
+          <View className="flex-1" />
+          <Text type="tertiary" className="text-xs">
+            已加载 {flattenedResults.length} 条
+          </Text>
+        </View>
+      ) : null}
+
       {!isSearching &&
       suggestions?.suggest &&
       suggestions.suggest.length > 0 ? (
@@ -356,6 +657,7 @@ export default function SearchScreen() {
           }}
           {...({
             estimatedItemSize: searchType === 'people' ? 80 : 150,
+            contentContainerStyle: { paddingTop: 4, paddingBottom: 18 },
             onEndReached: () =>
               hasNextPage && !isFetchingNextPage && fetchNextPage(),
             onEndReachedThreshold: 0.5,
@@ -363,8 +665,32 @@ export default function SearchScreen() {
               <ActivityIndicator style={{ padding: 20 }} color={tintColor} />
             ) : null,
             ListEmptyComponent: !isLoading ? (
-              <View className="flex-1 justify-center items-center">
-                <Text type="secondary">没有找到相关内容</Text>
+              <View className="flex-1 items-center justify-center px-10 py-24">
+                <Ionicons
+                  name={emptyStateIcon}
+                  size={38}
+                  color={Colors[colorScheme].textTertiary}
+                />
+                <Text className="mt-3 text-base font-semibold">
+                  没有找到相关内容
+                </Text>
+                <Text
+                  type="secondary"
+                  className="mt-1 text-center text-sm leading-5"
+                >
+                  {activeFilterCount > 0
+                    ? '可以放宽筛选条件，或者换一个关键词试试'
+                    : '可以换一个关键词，或者试试更具体的描述'}
+                </Text>
+                {activeFilterCount > 0 ? (
+                  <BouncyButton
+                    className="mt-4 px-4 py-2 rounded-full"
+                    style={{ backgroundColor: surfaceColor }}
+                    onPress={clearFilters}
+                  >
+                    <Text style={{ color: tintColor }}>清除筛选</Text>
+                  </BouncyButton>
+                ) : null}
               </View>
             ) : (
               <ActivityIndicator style={{ marginTop: 50 }} color={tintColor} />

--- a/components/AnswerDetailView.tsx
+++ b/components/AnswerDetailView.tsx
@@ -31,6 +31,7 @@ import { ActionSheet } from '@/components/overlays/ActionSheet';
 import { ShareMenu } from '@/components/ShareMenu';
 import { Text, ThemedIcon, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
+import { VoterListModal } from '@/components/VoterListModal';
 import Colors from '@/constants/Colors';
 import { RICH_CONTENT_STALE_TIME, ZhihuContent } from '@/features/rich-content';
 import { useOptimisticToggle } from '@/hooks/useOptimisticToggle';
@@ -88,6 +89,7 @@ export const AnswerDetailView = ({
   const [isLiked, setIsLiked] = React.useState(false);
   const [menuVisible, setMenuVisible] = React.useState(false);
   const [isSharing, setIsSharing] = React.useState(false);
+  const [votersVisible, setVotersVisible] = React.useState(false);
   const [hasBeenFocused, setHasBeenFocused] = React.useState(isFocused);
 
   React.useEffect(() => {
@@ -521,6 +523,14 @@ export const AnswerDetailView = ({
         }
       />
 
+      <VoterListModal
+        visible={votersVisible}
+        onClose={() => setVotersVisible(false)}
+        contentType="answer"
+        contentId={id}
+        count={answer?.voteup_count}
+      />
+
       <ActionSheet
         visible={menuVisible && !isSharing}
         onClose={() => setMenuVisible(false)}
@@ -546,6 +556,21 @@ export const AnswerDetailView = ({
             label: '分享回答',
             onPress: () => setIsSharing(true),
           },
+          ...(answer?.relationship?.is_author
+            ? [
+                {
+                  key: 'edit',
+                  icon: 'create-outline' as const,
+                  label: '编辑回答',
+                  onPress: () => {
+                    const targetQuestionId = answer.question?.id || questionId;
+                    if (targetQuestionId) {
+                      router.push(`/question/write/${targetQuestionId}`);
+                    }
+                  },
+                },
+              ]
+            : []),
           ...(answer?.relationship?.is_author
             ? [
                 {

--- a/components/VoterListModal.tsx
+++ b/components/VoterListModal.tsx
@@ -1,0 +1,159 @@
+import { FlashList } from '@shopify/flash-list';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useRouter } from 'expo-router';
+import { ActivityIndicator, Image, StyleSheet } from 'react-native';
+import type { ZhihuVoter, ZhihuVotersResponse } from '@/api/zhihu/voters';
+import { getAnswerVoters, getPinVoters } from '@/api/zhihu/voters';
+import { BouncyButton } from '@/components/BouncyButton';
+import { BottomSheet } from '@/components/overlays/BottomSheet';
+import { Text, useThemeColor, View } from '@/components/Themed';
+import { useColorScheme } from '@/components/useColorScheme';
+import Colors from '@/constants/Colors';
+
+interface VoterListModalProps {
+  visible: boolean;
+  onClose: () => void;
+  contentType: 'answer' | 'pin';
+  contentId: string | number;
+  count?: number;
+}
+
+function getNextOffset(
+  lastPage: ZhihuVotersResponse,
+  pages: ZhihuVotersResponse[],
+): number | undefined {
+  if (lastPage.paging?.is_end) return undefined;
+  const match = lastPage.paging?.next?.match(/offset=(\d+)/);
+  if (match) return Number(match[1]);
+  const loadedCount = pages.reduce(
+    (total, page) => total + page.data.length,
+    0,
+  );
+  return lastPage.data.length > 0 ? loadedCount : undefined;
+}
+
+export function VoterListModal({
+  visible,
+  onClose,
+  contentType,
+  contentId,
+  count,
+}: VoterListModalProps) {
+  const router = useRouter();
+  const colorScheme = useColorScheme();
+  const primaryColor = useThemeColor({}, 'primary');
+  const query = useInfiniteQuery({
+    queryKey: ['voters', contentType, String(contentId)],
+    queryFn: ({ pageParam = 0 }) =>
+      contentType === 'answer'
+        ? getAnswerVoters(contentId, 20, pageParam)
+        : getPinVoters(contentId, 20, pageParam),
+    initialPageParam: 0,
+    enabled: visible,
+    getNextPageParam: (lastPage, pages) => getNextOffset(lastPage, pages),
+  });
+
+  const voters = query.data?.pages.flatMap((page) => page.data) ?? [];
+  const uniqueVoters = voters.filter(
+    (voter, index, list) =>
+      list.findIndex((item) => String(item.id) === String(voter.id)) === index,
+  );
+
+  const renderVoter = ({ item }: { item: ZhihuVoter }) => {
+    const userToken = item.url_token || item.id;
+    return (
+      <BouncyButton
+        className="flex-row items-center px-5 py-3"
+        onPress={() => {
+          onClose();
+          router.push(`/user/${userToken}`);
+        }}
+      >
+        {item.avatar_url ? (
+          <Image source={{ uri: item.avatar_url }} style={styles.avatar} />
+        ) : (
+          <View
+            style={[
+              styles.avatar,
+              { backgroundColor: Colors[colorScheme].border },
+            ]}
+          />
+        )}
+        <View className="flex-1 ml-3 bg-transparent">
+          <Text className="font-semibold" numberOfLines={1}>
+            {item.name}
+          </Text>
+          {item.headline ? (
+            <Text type="secondary" className="text-xs mt-0.5" numberOfLines={1}>
+              {item.headline}
+            </Text>
+          ) : null}
+        </View>
+      </BouncyButton>
+    );
+  };
+
+  return (
+    <BottomSheet
+      visible={visible}
+      onClose={onClose}
+      title="赞同者"
+      subtitle={typeof count === 'number' ? `${count} 人赞同` : undefined}
+      height="72%"
+    >
+      {query.isLoading ? (
+        <View className="flex-1 items-center justify-center py-12">
+          <ActivityIndicator color={primaryColor} />
+        </View>
+      ) : query.isError ? (
+        <View className="items-center justify-center px-5 py-12">
+          <Text type="secondary">赞同者暂时加载失败</Text>
+          <BouncyButton
+            className="mt-3 px-4 py-2 rounded-full"
+            style={{ backgroundColor: Colors[colorScheme].primaryTransparent }}
+            onPress={() => void query.refetch()}
+          >
+            <Text style={{ color: primaryColor }}>重试</Text>
+          </BouncyButton>
+        </View>
+      ) : (
+        <FlashList
+          data={uniqueVoters}
+          renderItem={renderVoter}
+          keyExtractor={(item) => String(item.id)}
+          onEndReached={() => {
+            if (query.hasNextPage && !query.isFetchingNextPage) {
+              void query.fetchNextPage();
+            }
+          }}
+          onEndReachedThreshold={0.45}
+          ListEmptyComponent={
+            <View className="items-center py-12">
+              <Text type="secondary">还没有公开的赞同者</Text>
+            </View>
+          }
+          ListFooterComponent={
+            query.isFetchingNextPage ? (
+              <ActivityIndicator color={primaryColor} style={styles.footer} />
+            ) : null
+          }
+          {...({ estimatedItemSize: 68 } as object)}
+        />
+      )}
+      <Text type="tertiary" className="px-5 py-2 text-center text-xs">
+        赞同者列表由知乎接口返回，可能受隐私设置影响
+      </Text>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  avatar: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+  },
+  footer: {
+    paddingVertical: 16,
+  },
+});

--- a/features/publishing/index.ts
+++ b/features/publishing/index.ts
@@ -1,6 +1,7 @@
 export { PublishingEditor } from './PublishingEditor';
 export { PublishingMediaPicker } from './PublishingMediaPicker';
 export {
+  deserializePublishingHtml,
   serializePinText,
   serializePublishingMarkdown,
 } from './serializer';

--- a/features/publishing/serializer.ts
+++ b/features/publishing/serializer.ts
@@ -207,6 +207,57 @@ export function serializePublishingMarkdown(
   return blocks.join('');
 }
 
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&amp;/gi, '&');
+}
+
+function stripHtmlTags(value: string): string {
+  return value.replace(/<[^>]+>/g, '');
+}
+
+/** Convert the editable HTML returned by Zhihu back into the editor's small Markdown subset. */
+export function deserializePublishingHtml(html: string): string {
+  let markdown = html
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<(?:script|style)[^>]*>[\s\S]*?<\/(?:script|style)>/gi, '');
+
+  markdown = markdown.replace(
+    /<img\b[^>]*?(?:src|data-original-src)=["']([^"']+)["'][^>]*>/gi,
+    (_match, rawUrl: string) => {
+      const safeUrl = getSafeUrl(rawUrl);
+      return safeUrl ? `![图片](${safeUrl})` : '';
+    },
+  );
+  markdown = markdown.replace(
+    /<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
+    (_match, rawUrl: string, rawLabel: string) => {
+      const label = decodeHtmlEntities(stripHtmlTags(rawLabel)).trim();
+      const safeUrl = getSafeUrl(rawUrl);
+      return safeUrl && label ? `[${label}](${safeUrl})` : label;
+    },
+  );
+  markdown = markdown
+    .replace(/<(?:strong|b)\b[^>]*>([\s\S]*?)<\/(?:strong|b)>/gi, '**$1**')
+    .replace(/<(?:em|i)\b[^>]*>([\s\S]*?)<\/(?:em|i)>/gi, '*$1*')
+    .replace(/<code\b[^>]*>([\s\S]*?)<\/code>/gi, '`$1`')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<li\b[^>]*>/gi, '- ')
+    .replace(/<blockquote\b[^>]*>/gi, '> ')
+    .replace(/<\/?(?:p|div|h[1-6]|li|blockquote)\b[^>]*>/gi, '\n')
+    .replace(/<[^>]+>/g, '');
+
+  return decodeHtmlEntities(markdown)
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 /** Pins use plain paragraph HTML; their images live in `data.media.medias`. */
 export function serializePinText(text: string): string {
   const normalized = text.replace(/\r\n?/g, '\n').trim();

--- a/store/useAuthStore.ts
+++ b/store/useAuthStore.ts
@@ -70,9 +70,13 @@ interface AuthState {
   cookies: string | null;
   me: ZhihuMeInfo | null; // 存储个人详细信息
   setCookies: (cookies: string) => void;
+  updateActiveAccountCookies: (cookies: string) => void;
   setMe: (me: ZhihuMeInfo) => void;
   addAccount: (cookies: string, me: ZhihuMeInfo) => void;
-  switchAccount: (index: number) => void;
+  switchAccount: (
+    index: number,
+    verifiedSession?: { cookies: string; me: ZhihuMeInfo },
+  ) => void;
   removeAccount: (index: number) => void;
   logout: () => void;
 }
@@ -100,6 +104,21 @@ export const useAuthStore = create<AuthState>()(
 
       setCookies: (cookies) => {
         set({ cookies });
+      },
+
+      updateActiveAccountCookies: (cookies) => {
+        const { accounts, activeAccountIndex } = get();
+        if (activeAccountIndex < 0 || activeAccountIndex >= accounts.length) {
+          set({ cookies });
+          return;
+        }
+        const nextAccounts = [...accounts];
+        nextAccounts[activeAccountIndex] = {
+          ...nextAccounts[activeAccountIndex],
+          cookies,
+          last_updated: Date.now(),
+        };
+        set({ accounts: nextAccounts, cookies });
       },
 
       setMe: (me) => {
@@ -146,7 +165,7 @@ export const useAuthStore = create<AuthState>()(
         }
       },
 
-      switchAccount: (index) => {
+      switchAccount: (index, verifiedSession) => {
         if (index === -1) {
           set({
             activeAccountIndex: -1,
@@ -158,10 +177,24 @@ export const useAuthStore = create<AuthState>()(
         const { accounts } = get();
         if (index >= 0 && index < accounts.length) {
           const account = accounts[index];
+          const nextAccount = verifiedSession
+            ? {
+                ...account,
+                cookies: verifiedSession.cookies,
+                me: verifiedSession.me,
+                last_updated: Date.now(),
+              }
+            : account;
+          const nextAccounts = verifiedSession
+            ? accounts.map((item, accountIndex) =>
+                accountIndex === index ? nextAccount : item,
+              )
+            : accounts;
           set({
+            accounts: nextAccounts,
             activeAccountIndex: index,
-            cookies: account.cookies,
-            me: account.me,
+            cookies: nextAccount.cookies,
+            me: nextAccount.me,
           });
         }
       },

--- a/tests/publishing.test.mjs
+++ b/tests/publishing.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  deserializePublishingHtml,
   serializePinText,
   serializePublishingMarkdown,
 } from '../features/publishing/serializer.ts';
@@ -63,5 +64,14 @@ test('serializes pin text without treating it as rich Markdown', () => {
   assert.equal(
     serializePinText('第一行 **不是粗体**\n\n<script>'),
     '<p>第一行 **不是粗体**</p><p><br></p><p>&lt;script&gt;</p>',
+  );
+});
+
+test('deserializes editable answer HTML into the publishing Markdown subset', () => {
+  assert.equal(
+    deserializePublishingHtml(
+      '<p>普通 <strong>粗体</strong> 和 <a href="https://example.com">链接</a></p><ul><li>一</li><li>二</li></ul>',
+    ),
+    '普通 **粗体** 和 [链接](https://example.com/)\n- 一\n- 二',
   );
 });

--- a/types/zhihu.ts
+++ b/types/zhihu.ts
@@ -109,6 +109,11 @@ export interface ZhihuQuestion {
     is_anonymous?: boolean;
     is_thanked?: boolean;
     is_nothelp?: boolean;
+    my_answer?: {
+      id?: string | number;
+      answer_id?: string | number;
+      is_deleted?: boolean;
+    } | null;
   };
 }
 
@@ -180,6 +185,31 @@ export interface ZhihuPin {
   relationship?: {
     voting?: number;
   };
+  bottom_poll?: {
+    voting?: ZhihuPinPoll;
+    pk?: ZhihuPinPoll;
+  };
+}
+
+export interface ZhihuPinPoll {
+  id: string;
+  title?: string;
+  max_selections?: number;
+  type?: string;
+  begin_at?: number;
+  end_at?: number;
+  voting_count?: number;
+  member_count?: number;
+  is_voted?: boolean;
+  is_reviewing?: boolean;
+  options: ZhihuPinPollOption[];
+}
+
+export interface ZhihuPinPollOption {
+  id: string;
+  title: string;
+  voting_count?: number;
+  is_selected?: boolean;
 }
 
 export interface ZhihuVideo {


### PR DESCRIPTION
## Summary

- add existing-answer detection/editing and Zhihu search filters
- add voter APIs/modal implementation; keep the voter entry hidden for now
- add pin poll voting and result states
- add 401 refresh with a single retry, Set-Cookie merging, and target-session verification before account switching
- refine the search results UI with a compact filter toolbar, filter sheet, result context, and empty state

## Validation

- `npm run check`
- `npm run typecheck`
- `git diff --check`

Live-device validation against a real Zhihu session is still pending.