### PR TITLE
fix: add stable navigation titles

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -239,18 +239,13 @@ function RootLayout() {
                   },
                   headerTintColor: currentTint,
                   headerShadowVisible: false,
+                  headerBackButtonDisplayMode: 'minimal',
                 }}
               >
                 {/* 底部 Tab 主框架 */}
-                <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-
-                {/* 文章详情页：从右侧推入 */}
                 <Stack.Screen
-                  name="article/[id]"
-                  options={{
-                    headerTitle: '正文',
-                    headerBackTitle: '返回',
-                  }}
+                  name="(tabs)"
+                  options={{ headerShown: false, title: '知乎' }}
                 />
 
                 {/* 登录页：建议做成从底部弹出的 Modal */}
@@ -258,7 +253,6 @@ function RootLayout() {
                   name="login/index"
                   options={{
                     presentation: 'modal',
-                    headerTitle: '登录知乎',
                     headerLeft: () => null,
                   }}
                 />

--- a/app/answer/[id].tsx
+++ b/app/answer/[id].tsx
@@ -212,6 +212,7 @@ export default function AnswerDetailScreen() {
   if (loadingInitial && !initialAnswer) {
     return (
       <View className="flex-1 justify-center items-center">
+        <Stack.Screen options={{ headerShown: false, title: '回答' }} />
         <ActivityIndicator color={primaryColor} />
       </View>
     );
@@ -219,7 +220,7 @@ export default function AnswerDetailScreen() {
 
   return (
     <View className="flex-1">
-      <Stack.Screen options={{ headerShown: false }} />
+      <Stack.Screen options={{ headerShown: false, title: '回答' }} />
 
       {/* Header Bar */}
       <View

--- a/app/article/[id].tsx
+++ b/app/article/[id].tsx
@@ -203,6 +203,7 @@ export default function ArticleDetail() {
   if (isLoading) {
     return (
       <View className="flex-1 justify-center items-center">
+        <Stack.Screen options={{ headerShown: false, title: '正文' }} />
         <ActivityIndicator size="large" color={primaryColor} />
         <Text className="mt-3">正赶往知识的荒原...喵</Text>
       </View>
@@ -212,6 +213,7 @@ export default function ArticleDetail() {
   if (!data) {
     return (
       <View className="flex-1 justify-center items-center px-6">
+        <Stack.Screen options={{ headerShown: false, title: '正文' }} />
         <Ionicons
           name="compass-outline"
           size={48}
@@ -239,7 +241,7 @@ export default function ArticleDetail() {
   return (
     <View className="flex-1">
       {/* Hide native header */}
-      <Stack.Screen options={{ headerShown: false }} />
+      <Stack.Screen options={{ headerShown: false, title: '正文' }} />
 
       {/* Floating Header Bar */}
       <View

--- a/app/feedback/index.tsx
+++ b/app/feedback/index.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { Linking, ScrollView, StyleSheet } from 'react-native';
 import { BouncyButton } from '@/components/BouncyButton';
 import { Text, useThemeColor, View } from '@/components/Themed';
@@ -15,6 +15,7 @@ export default function FeedbackScreen() {
 
   return (
     <View className="flex-1">
+      <Stack.Screen options={{ headerShown: false, title: '反馈与建议' }} />
       {/* 顶部标题栏 */}
       <View
         type="surface"

--- a/app/guest/detail.tsx
+++ b/app/guest/detail.tsx
@@ -42,7 +42,7 @@ export default function GuestDetailScreen() {
         style={[styles.centerContainer, { backgroundColor }]}
         type="default"
       >
-        <Stack.Screen options={{ headerShown: false }} />
+        <Stack.Screen options={{ headerShown: false, title: '内容预览' }} />
         <Ionicons
           name="alert-circle-outline"
           size={48}
@@ -97,7 +97,7 @@ export default function GuestDetailScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor }]} type="default">
-      <Stack.Screen options={{ headerShown: false }} />
+      <Stack.Screen options={{ headerShown: false, title: '内容预览' }} />
 
       {/* 顶部标题导航栏 */}
       <View

--- a/app/login/index.tsx
+++ b/app/login/index.tsx
@@ -1,6 +1,6 @@
 import CookieManager from '@preeternal/react-native-cookie-manager';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { useRef, useState } from 'react';
 import { ActivityIndicator, StyleSheet } from 'react-native';
 import { WebView } from 'react-native-webview';
@@ -110,6 +110,7 @@ export default function LoginScreen() {
 
   return (
     <View className="flex-1">
+      <Stack.Screen options={{ title: '登录知乎' }} />
       {/* 顶部标题栏 */}
       <View
         type="surface"

--- a/app/publish/answer.tsx
+++ b/app/publish/answer.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useQuery } from '@tanstack/react-query';
-import { useRouter } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { ActivityIndicator, FlatList, TextInput } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -105,6 +105,7 @@ export default function PublishAnswerScreen() {
 
   return (
     <View className="flex-1">
+      <Stack.Screen options={{ headerShown: false, title: '写回答' }} />
       {/* Header */}
       <View
         className="flex-row items-center justify-between px-4 pb-3"

--- a/app/publish/article.tsx
+++ b/app/publish/article.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { useState } from 'react';
 import {
   ActivityIndicator,
@@ -89,6 +89,7 @@ export default function PublishArticleScreen() {
 
   return (
     <View className="flex-1">
+      <Stack.Screen options={{ headerShown: false, title: '写文章' }} />
       <View
         className="flex-row items-center justify-between px-4 pb-3"
         style={{ paddingTop: insets.top + 10 }}

--- a/app/publish/pin.tsx
+++ b/app/publish/pin.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { useState } from 'react';
 import {
   ActivityIndicator,
@@ -69,6 +69,7 @@ export default function PublishPinScreen() {
 
   return (
     <View className="flex-1">
+      <Stack.Screen options={{ headerShown: false, title: '发想法' }} />
       <View
         className="flex-row items-center justify-between px-4 pb-3"
         style={{ paddingTop: insets.top + 10 }}

--- a/app/publish/question.tsx
+++ b/app/publish/question.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { useState } from 'react';
 import {
   ActivityIndicator,
@@ -70,6 +70,7 @@ export default function PublishQuestionScreen() {
 
   return (
     <View className="flex-1">
+      <Stack.Screen options={{ headerShown: false, title: '提问题' }} />
       <View
         className="flex-row items-center justify-between px-4 pb-3"
         style={{ paddingTop: insets.top + 10 }}

--- a/app/question/[id]/index.tsx
+++ b/app/question/[id]/index.tsx
@@ -1263,7 +1263,7 @@ export default function QuestionDetail() {
 
   return (
     <View type="default" className="flex-1">
-      <Stack.Screen options={{ headerShown: false }} />
+      <Stack.Screen options={{ headerShown: false, title: '问题' }} />
 
       <ShareMenu
         visible={isSharing}

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -371,7 +371,7 @@ export default function SearchScreen() {
 
   return (
     <View className="flex-1">
-      <Stack.Screen options={{ headerShown: false }} />
+      <Stack.Screen options={{ headerShown: false, title: '搜索' }} />
 
       {/* Header */}
       <View className="pt-[45px] pb-2.5 px-[5px]" style={{ backgroundColor }}>

--- a/app/user/[id]/stream.tsx
+++ b/app/user/[id]/stream.tsx
@@ -806,7 +806,7 @@ export default function UserStreamScreen() {
         backgroundColor: Colors[colorScheme].background,
       }}
     >
-      <Stack.Screen options={{ headerShown: false }} />
+      <Stack.Screen options={{ headerShown: false, title: '个人动态' }} />
       {isUserLoading ? (
         <View className="flex-1 items-center justify-center bg-transparent">
           <ActivityIndicator color={primaryColor} />


### PR DESCRIPTION
## Summary
- use minimal iOS back buttons so route filenames are never exposed
- colocate stable titles with screens, including loading and error states
- keep layout-level titles only for navigator nodes

## Verification
- npm run check

## Not tested
- iOS simulator or physical-device visual verification