### PR TITLE
feat: 接入用户最近发布流与已读状态

### DIFF
--- a/api/zhihu/member.ts
+++ b/api/zhihu/member.ts
@@ -3,6 +3,7 @@ import type {
   ZhihuMemberRelation,
   ZhihuPaging,
 } from '@/types/zhihu';
+import { getRecentActivityTargetId } from '@/utils/userProfile';
 import apiClient from '../client';
 
 export const MEMBER_INCLUDE =
@@ -40,9 +41,73 @@ export interface ZhihuListResponse<T> {
 
 export interface ZhihuMemberActivity {
   id?: string | number;
-  target?: ZhihuMemberRelation;
+  source?: {
+    action_text?: string;
+    action_time?: number;
+    action_type?: string;
+  };
+  target?: ZhihuMemberActivityTarget;
   type?: string;
   url?: string;
+}
+
+export interface ZhihuMemberActivityTarget {
+  id?: string | number;
+  type?: string;
+  url?: string;
+  title?: string;
+  excerpt?: string;
+  excerpt_title?: string;
+  content?: string | ZhihuMemberActivityContentSegment[];
+  image_url?: string;
+  thumbnail?: string;
+  voteup_count?: number;
+  reaction_count?: number;
+  comment_count?: number;
+  favlists_count?: number;
+  created?: number;
+  created_time?: number;
+  relationship?: { voting?: number };
+  author?: Partial<ZhihuAuthor>;
+  question?: {
+    id?: string | number;
+    title?: string;
+  };
+  [key: string]: unknown;
+}
+
+export interface ZhihuMemberActivityContentSegment {
+  type: string;
+  content?: string;
+  own_text?: string;
+  url?: string;
+  data_draft_cover?: string;
+}
+
+export interface ZhihuRecentActivityCursor {
+  offset: number;
+  pageNum: number;
+}
+
+interface RawZhihuMemberActivity extends Omit<ZhihuMemberActivity, 'target'> {
+  source?: {
+    action_text?: string;
+    action_time?: number;
+    action_type?: string;
+  };
+  target?: {
+    id?: string | number;
+    type?: string;
+    url?: string;
+    created?: number;
+    created_time?: number;
+    reaction_relation?: { vote?: number | string };
+    relationship?: {
+      voting?: number | string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
 }
 
 export interface ZhihuFollowResponse {
@@ -93,6 +158,64 @@ export const getMemberActivities = async (
     },
   });
   return res.data;
+};
+
+/** 获取「最近更新」入口对应用户的纯发布流。 */
+export const getRecentMemberActivities = async (
+  memberId: string | number,
+  cursor: ZhihuRecentActivityCursor,
+): Promise<ZhihuListResponse<ZhihuMemberActivity>> => {
+  const url = `https://api.zhihu.com/moments/recent/people/${memberId}/activities`;
+  const res = await apiClient.get<ZhihuListResponse<RawZhihuMemberActivity>>(
+    url,
+    {
+      params: {
+        action: 'down',
+        offset: cursor.offset,
+        page_num: cursor.pageNum,
+      },
+      headers: {
+        'x-api-version': '3.0.93',
+        'x-page-id': '10103',
+      },
+    },
+  );
+
+  return {
+    ...res.data,
+    data: res.data.data.map((activity) => {
+      const { source, target } = activity;
+      if (!target) {
+        return {
+          id: activity.id,
+          source,
+          type: activity.type,
+          url: activity.url,
+        };
+      }
+
+      const voting =
+        target.relationship?.voting ?? target.reaction_relation?.vote;
+      const normalizedVoting =
+        voting === undefined ? undefined : Number(voting);
+
+      return {
+        ...activity,
+        target: {
+          ...target,
+          // Pin ids exceed Number.MAX_SAFE_INTEGER. The URL retains the exact
+          // decimal string after JSON parsing, while the numeric id does not.
+          id: getRecentActivityTargetId(target),
+          type: target.type === 'moments_pin' ? 'pin' : target.type,
+          created: target.created ?? target.created_time ?? source?.action_time,
+          relationship:
+            normalizedVoting !== undefined && Number.isFinite(normalizedVoting)
+              ? { ...target.relationship, voting: normalizedVoting }
+              : undefined,
+        },
+      };
+    }),
+  };
 };
 
 export const getMemberRelations = async (

--- a/api/zhihu/moments.ts
+++ b/api/zhihu/moments.ts
@@ -13,6 +13,10 @@ export interface ZhihuActor {
 }
 
 export interface RecentMomentItem {
+  /** Some response variants expose the read token as the feed entry id. */
+  id?: string;
+  /** Opaque token used by the recent-person read endpoint. */
+  brief?: string;
   actor: ZhihuActor;
   unread_count: number;
 }
@@ -34,5 +38,28 @@ export interface RecentMomentsResponse {
 export const fetchRecentMoments = async (): Promise<RecentMomentsResponse> => {
   const url = 'https://api.zhihu.com/moments/recent?type=raw';
   const response = await apiClient.get<RecentMomentsResponse>(url);
+  return response.data;
+};
+
+export interface MarkRecentMomentsReadResponse {
+  success: boolean;
+}
+
+/** Mark one recent-person entry as read using its opaque response token. */
+export const markRecentMomentsRead = async (
+  readToken: string,
+): Promise<MarkRecentMomentsReadResponse> => {
+  const url = 'https://api.zhihu.com/moments/recent/read';
+  const response = await apiClient.post<MarkRecentMomentsReadResponse>(
+    url,
+    undefined,
+    {
+      params: { brief: readToken },
+      headers: {
+        'x-api-version': '3.0.93',
+        'x-page-id': '10103',
+      },
+    },
+  );
   return response.data;
 };

--- a/app/user/[id]/stream.tsx
+++ b/app/user/[id]/stream.tsx
@@ -1,1084 +1,279 @@
 import { Ionicons } from '@expo/vector-icons';
-import {
-  FlashList,
-  type FlashListRef,
-  type ListRenderItemInfo,
-  type ViewToken,
-} from '@shopify/flash-list';
+import { FlashList } from '@shopify/flash-list';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
-import { BlurView } from 'expo-blur';
-import { LinearGradient } from 'expo-linear-gradient';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react';
-import {
-  ActivityIndicator,
-  Image,
-  LayoutAnimation,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
-  View as NativeView,
-  Platform,
-  Pressable,
-  UIManager,
-  useWindowDimensions,
-} from 'react-native';
-import Reanimated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-} from 'react-native-reanimated';
+import { useRef } from 'react';
+import { ActivityIndicator, Image } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
-  getMemberActivities,
-  getMemberRelations,
+  type FeedItem,
   getMemberWithFallback,
-  MEMBER_ANSWERS_INCLUDE,
+  getRecentMemberActivities,
+  type ZhihuMember,
+  type ZhihuMemberActivity,
 } from '@/api/zhihu';
-import type { ZhihuMemberActivity } from '@/api/zhihu/member';
 import { BouncyButton } from '@/components/BouncyButton';
-import { LikeButton } from '@/components/LikeButton';
+import { FeedCard } from '@/components/FeedCard';
 import { QueryErrorView } from '@/components/QueryErrorView';
-import { ShareMenu } from '@/components/ShareMenu';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
-import { ZhihuContent } from '@/features/rich-content';
-import { useCollectionAction } from '@/hooks/useCollectionAction';
-import { useCollectionStore } from '@/store/useCollectionStore';
-import type { ZhihuMemberRelation } from '@/types/zhihu';
-import { formatDate } from '@/utils/date';
-import { getNextPageOffset } from '@/utils/userProfile';
+import {
+  getNextRecentActivityCursor,
+  getRecentActivityReadBoundary,
+  normalizeUserFeedType,
+  type RecentActivityCursor,
+} from '@/utils/userProfile';
 
-type StreamTab = 'activities' | 'answers' | 'questions' | 'articles' | 'pins';
-type StreamItemType = 'answer' | 'article' | 'question' | 'pin' | 'video';
-type StreamApiItem = ZhihuMemberActivity | ZhihuMemberRelation;
-
-interface StreamContentSegment {
-  type?: string;
-  content?: string;
-  data_draft_title?: string;
+function getPublishedExcerpt(
+  target: NonNullable<ZhihuMemberActivity['target']>,
+) {
+  if (Array.isArray(target.content)) {
+    return target.content
+      .filter((segment) => segment.type === 'text')
+      .map((segment) => segment.content || segment.own_text || '')
+      .join('')
+      .replace(/<[^>]+>/g, '')
+      .slice(0, 150);
+  }
+  const text = target.excerpt || target.excerpt_title || target.content || '';
+  return typeof text === 'string'
+    ? text.replace(/<[^>]+>/g, '').slice(0, 150)
+    : '';
 }
 
-interface StreamContentItem {
-  id: string | number;
-  type?: string;
-  url?: string;
-  title?: string;
-  content?: string | StreamContentSegment[];
-  excerpt?: string;
-  voteup_count?: number;
-  like_count?: number;
-  reaction_count?: number;
-  comment_count?: number;
-  favlists_count?: number;
-  favlistsCount?: number;
-  favorite_count?: number;
-  answer_count?: number;
-  follower_count?: number;
-  created?: number;
-  created_time?: number;
-  updated?: number;
-  updated_time?: number;
-  link_card_info?: Record<string, string>;
-  author?: { name?: string; headline?: string };
-  question?: { id?: string | number; title?: string };
-  relationship?: { voting?: number };
-  reaction?: {
-    statistics?: {
-      favorites?: number;
-      like_count?: number;
-    };
+function toFeedItem(
+  activity: ZhihuMemberActivity,
+  member: ZhihuMember,
+): FeedItem | null {
+  const target = activity.target;
+  if (!target?.id) return null;
+
+  const type = normalizeUserFeedType(target.type);
+  if (!type) return null;
+
+  const contentImage = Array.isArray(target.content)
+    ? target.content.find((segment) => segment.type === 'image')
+    : undefined;
+  const author = target.author;
+
+  return {
+    id: String(target.id),
+    title: target.question?.title || target.title || '',
+    actionText: activity.source?.action_text,
+    questionId:
+      target.question?.id !== undefined
+        ? String(target.question.id)
+        : type === 'questions'
+          ? String(target.id)
+          : undefined,
+    author: {
+      id: author?.id || member.id,
+      url_token: author?.url_token || member.url_token,
+      name: author?.name || member.name,
+      avatar: author?.avatar_url || member.avatar_url,
+      headline: author?.headline || member.headline,
+    },
+    excerpt: getPublishedExcerpt(target),
+    content: target.content,
+    image:
+      target.image_url ||
+      target.thumbnail ||
+      contentImage?.url ||
+      contentImage?.data_draft_cover ||
+      null,
+    voteCount:
+      type === 'pins'
+        ? target.reaction_count || target.voteup_count || 0
+        : target.voteup_count || 0,
+    commentCount: target.comment_count || 0,
+    favlistsCount: target.favlists_count || 0,
+    voted: target.relationship?.voting || 0,
+    type,
   };
 }
 
-interface StreamItemHandle {
-  measureFooter: (
-    callback: (x: number, y: number, width: number, height: number) => void,
-  ) => void;
-  id: string;
-}
-
-interface StreamItemProps {
-  item: StreamContentItem;
-  type: StreamItemType;
-  isExpanded: boolean;
-  onToggle: (id: string, expanded: boolean) => void;
-  onShare: (item: StreamContentItem) => void;
-  isHighlighted: boolean;
-  isCollapsedHighlighted?: boolean;
-}
-
-function getDisplayItem(
-  item: StreamApiItem,
-  activeTab: StreamTab,
-): StreamContentItem | null {
-  const candidate =
-    activeTab === 'activities' && 'target' in item && item.target
-      ? item.target
-      : item;
-
-  if (!candidate || typeof candidate !== 'object' || !('id' in candidate)) {
-    return null;
-  }
-  if (candidate.id === null || candidate.id === undefined) return null;
-
-  return candidate as StreamContentItem;
-}
-
-function normalizeStreamTab(type: string | undefined): StreamTab {
-  return type === 'activities' ||
-    type === 'answers' ||
-    type === 'questions' ||
-    type === 'articles' ||
-    type === 'pins'
-    ? type
-    : 'answers';
-}
-
-const StreamItem = forwardRef<StreamItemHandle, StreamItemProps>(
-  (
-    {
-      item,
-      type,
-      isExpanded,
-      onToggle,
-      onShare,
-      isCollapsedHighlighted,
-    }: StreamItemProps,
-    ref,
-  ) => {
-    const colorScheme = useColorScheme();
-    const router = useRouter();
-    const footerRef = useRef<NativeView>(null);
-
-    const warningColor = useThemeColor({}, 'warning');
-    const primaryColor = useThemeColor({}, 'primary');
-    const isCollectable = type === 'answer' || type === 'article';
-    const storeCollected = useCollectionStore((state) =>
-      item?.id ? state.collectedStatusMap[item.id.toString()] : false,
-    );
-    const isCollected = storeCollected !== undefined ? storeCollected : false;
-    const storeOffset = useCollectionStore((state) =>
-      item?.id ? state.collectedCountOffsetMap[item.id.toString()] || 0 : 0,
-    );
-    const displayCount =
-      (item?.favlists_count ??
-        item?.favlistsCount ??
-        item?.favorite_count ??
-        item?.reaction?.statistics?.favorites ??
-        0) + storeOffset;
-    const { toggleCollect } = useCollectionAction();
-
-    useImperativeHandle(ref, () => ({
-      measureFooter: (callback) => footerRef.current?.measureInWindow(callback),
-      id: item.id.toString(),
-    }));
-
-    const getFullContent = () => {
-      if (!item) return '';
-      if (type === 'pin' && Array.isArray(item.content)) {
-        return item.content
-          .map((segment) => {
-            if (segment.type === 'text') return segment.content;
-            if (segment.type === 'link_card')
-              return `[链接: ${segment.data_draft_title || '查看详情'}]`;
-            return '';
-          })
-          .join('\n')
-          .replace(/<[^>]+>/g, '');
-      }
-      const content = item.content || item.excerpt || '';
-      if (typeof content === 'string') {
-        return content.replace(/<[^>]+>/g, '');
-      }
-      return '';
+type PublishedStreamRow =
+  | {
+      key: string;
+      kind: 'content';
+      item: FeedItem;
+    }
+  | {
+      key: 'read-boundary';
+      kind: 'read-boundary';
     };
 
-    const getExcerpt = () => {
-      if (!item) return '';
-
-      if (type === 'pin') {
-        if (Array.isArray(item.content)) {
-          return item.content
-            .filter((segment) => segment.type === 'text')
-            .map((segment) => segment.content)
-            .join('')
-            .replace(/<[^>]+>/g, '')
-            .substring(0, 100);
-        }
-        if (typeof item.content === 'string') {
-          return item.content.replace(/<[^>]+>/g, '').substring(0, 100);
-        }
-      }
-
-      const content = item.excerpt || item.content || '';
-      if (typeof content === 'string') {
-        return content.replace(/<[^>]+>/g, '').substring(0, 100);
-      }
-      return '';
-    };
-
-    const getTitle = () => {
-      if (type === 'pin') return '发布了想法';
-      if (type === 'video') return item.title || '发布了视频';
-      return item.title || item.question?.title || '未知内容';
-    };
-
-    const handlePress = () => {
-      if (type === 'answer' || type === 'article' || type === 'pin') {
-        onToggle(item.id.toString(), !isExpanded);
-        return;
-      }
-      if (type === 'video') {
-        router.push({
-          pathname: '/video/[id]',
-          params: { id: item.id, title: item.title },
-        });
-      } else {
-        router.push({
-          pathname: `/${type}/[id]`,
-          params: {
-            id: item.id,
-            title: item.title || item.question?.title,
-            questionId: item.question?.id,
-          },
-        });
-      }
-    };
-
-    const fullText = getFullContent();
-    const isLongContent =
-      (type === 'answer' || type === 'article' || type === 'pin') &&
-      (fullText.length > 120 ||
-        (typeof item.content === 'string' &&
-          (item.content.includes('<img') || item.content.includes('<figure'))));
-    const itemTimestamp =
-      item.updated_time ?? item.updated ?? item.created_time ?? item.created;
-
-    return (
-      <BouncyButton
-        onPress={handlePress}
-        style={[
-          {
-            backgroundColor: Colors[colorScheme].backgroundSecondary,
-            borderRadius: 12,
-            borderWidth: 1.5,
-            borderColor: isCollapsedHighlighted ? primaryColor : 'transparent',
-          },
-        ]}
-        className="p-4 mb-2.5"
-      >
-        <Reanimated.View
-          sharedTransitionTag={`title-${item.question?.id || item.id}`}
-        >
-          <Text
-            className="text-lg font-bold mb-1.5 leading-6 text-foreground dark:text-foreground-dark"
-            numberOfLines={isExpanded ? undefined : 2}
-          >
-            {getTitle()}
-          </Text>
-        </Reanimated.View>
-
-        <View className="bg-transparent mt-1">
-          {!isLongContent ? (
-            <View className="flex-1 bg-transparent">
-              {type === 'answer' || type === 'article' || type === 'pin' ? (
-                <ZhihuContent
-                  objectId={item.id?.toString()}
-                  type={type === 'pin' ? 'pin' : type}
-                  content={
-                    typeof item.content === 'string' ? item.content : undefined
-                  }
-                  contentArray={
-                    type === 'pin' && Array.isArray(item.content)
-                      ? item.content
-                      : undefined
-                  }
-                  linkCardInfo={item.link_card_info}
-                  useNative={true}
-                />
-              ) : (
-                <Text
-                  type="secondary"
-                  className="text-[17px]"
-                  style={{ lineHeight: 27 }}
-                  numberOfLines={3}
-                >
-                  {getExcerpt()}
-                </Text>
-              )}
-            </View>
-          ) : isExpanded ? (
-            <View className="flex-1 bg-transparent">
-              <ZhihuContent
-                objectId={item.id?.toString()}
-                type={type === 'pin' ? 'pin' : type}
-                content={
-                  typeof item.content === 'string' ? item.content : undefined
-                }
-                contentArray={
-                  type === 'pin' && Array.isArray(item.content)
-                    ? item.content
-                    : undefined
-                }
-                linkCardInfo={item.link_card_info}
-                useNative={true}
-              />
-              <BouncyButton
-                onPress={() => item?.id && onToggle(item.id.toString(), false)}
-                className="flex-row items-center justify-center py-2.5 mt-1 bg-transparent"
-              >
-                <Text
-                  type="primary"
-                  className="text-[13px] font-bold mr-1"
-                  style={{ color: primaryColor }}
-                >
-                  收起
-                  {type === 'answer'
-                    ? '回答'
-                    : type === 'article'
-                      ? '文章'
-                      : '想法'}
-                </Text>
-                <Ionicons name="chevron-up" size={14} color={primaryColor} />
-              </BouncyButton>
-            </View>
-          ) : (
-            <Pressable
-              onPress={() => item?.id && onToggle(item.id.toString(), true)}
-              style={{ maxHeight: 150, overflow: 'hidden' }}
-              className="flex-1"
-            >
-              <Text
-                type="secondary"
-                className="text-[17px]"
-                style={{ lineHeight: 27 }}
-                numberOfLines={5}
-              >
-                {getExcerpt()}
-              </Text>
-              <Pressable
-                onPress={() => item?.id && onToggle(item.id.toString(), true)}
-                className="absolute inset-x-0 bottom-0 h-24 z-[100]"
-              >
-                <LinearGradient
-                  colors={[
-                    colorScheme === 'dark'
-                      ? 'rgba(30, 30, 34, 0)'
-                      : 'rgba(255, 255, 255, 0)',
-                    colorScheme === 'dark'
-                      ? 'rgba(30, 30, 34, 1)'
-                      : 'rgba(255, 255, 255, 1)',
-                  ]}
-                  style={{
-                    position: 'absolute',
-                    left: 0,
-                    right: 0,
-                    top: 0,
-                    bottom: 0,
-                    justifyContent: 'flex-end',
-                    alignItems: 'center',
-                    paddingBottom: 6,
-                  }}
-                >
-                  <Text
-                    type="primary"
-                    className="text-[13px] font-bold"
-                    style={{ color: primaryColor }}
-                  >
-                    展开全文
-                  </Text>
-                </LinearGradient>
-              </Pressable>
-            </Pressable>
-          )}
-        </View>
-
-        <NativeView
-          ref={footerRef}
-          className="flex-row justify-between mt-4 items-center bg-transparent"
-        >
-          {type !== 'question' && type !== 'video' ? (
-            <View className="flex-row items-center bg-transparent">
-              <LikeButton
-                id={item.id}
-                count={
-                  item.voteup_count ??
-                  (type === 'pin'
-                    ? item.reaction_count || item.like_count
-                    : 0) ??
-                  0
-                }
-                voted={item.relationship?.voting || 0}
-                type={
-                  type === 'article'
-                    ? 'articles'
-                    : type === 'pin'
-                      ? 'pins'
-                      : 'answers'
-                }
-                variant="ghost"
-              />
-              <BouncyButton
-                onPress={() => {
-                  const commentType =
-                    type === 'article'
-                      ? 'article'
-                      : type === 'pin'
-                        ? 'pin'
-                        : 'answer';
-                  router.push(
-                    `/comments/${item.id}?type=${commentType}&count=${item.comment_count || 0}`,
-                  );
-                }}
-                className="flex-row items-center justify-center ml-3 p-2 rounded-full bg-transparent"
-              >
-                <Ionicons
-                  name="chatbubble-outline"
-                  size={16}
-                  color={Colors[colorScheme].iconMuted}
-                />
-                <Text className="text-muted ml-1 text-xs font-semibold">
-                  {(item.comment_count ?? 0) > 0 ? item.comment_count : '评论'}
-                </Text>
-              </BouncyButton>
-              {isCollectable && (
-                <BouncyButton
-                  onPress={() => toggleCollect(item.id, type, isCollected)}
-                  className="flex-row items-center justify-center ml-3 p-2 rounded-full bg-transparent"
-                >
-                  <Ionicons
-                    name={isCollected ? 'star' : 'star-outline'}
-                    size={16}
-                    color={
-                      isCollected ? warningColor : Colors[colorScheme].iconMuted
-                    }
-                  />
-                  {displayCount > 0 && (
-                    <Text
-                      className="ml-1 text-xs font-semibold"
-                      style={{
-                        color: isCollected
-                          ? warningColor
-                          : Colors[colorScheme].iconMuted,
-                      }}
-                    >
-                      {displayCount}
-                    </Text>
-                  )}
-                </BouncyButton>
-              )}
-            </View>
-          ) : (
-            <Text
-              type="secondary"
-              className="text-xs text-tertiary dark:text-tertiary-dark"
-            >
-              {type === 'question'
-                ? `${item.answer_count || 0} 回答 · ${item.follower_count || 0} 关注`
-                : `${item.reaction?.statistics?.like_count || item.voteup_count || 0} 赞同 · ${item.comment_count || 0} 评论`}
-            </Text>
-          )}
-
-          <View className="flex-row items-center bg-transparent ml-auto">
-            <Text
-              type="secondary"
-              className="text-xs text-tertiary dark:text-tertiary-dark mr-3"
-            >
-              {itemTimestamp ? formatDate(itemTimestamp) : ''}
-            </Text>
-            <BouncyButton
-              onPress={() => onShare(item)}
-              className="p-1 -mr-1 bg-transparent"
-            >
-              <Ionicons
-                name="ellipsis-horizontal"
-                size={18}
-                color={Colors[colorScheme].iconMuted}
-              />
-            </BouncyButton>
-          </View>
-        </NativeView>
-      </BouncyButton>
-    );
-  },
-);
+function parseUnreadCount(value: string | undefined) {
+  if (!value) return 0;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
 
 export default function UserStreamScreen() {
-  const { id, type, initialId } = useLocalSearchParams<{
+  const { id, unreadCount } = useLocalSearchParams<{
     id: string;
-    type: string;
-    initialId?: string;
+    unreadCount?: string;
   }>();
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   const colorScheme = useColorScheme();
   const primaryColor = useThemeColor({}, 'primary');
-  const insets = useSafeAreaInsets();
-  const flashListRef = useRef<FlashListRef<StreamApiItem>>(null);
-  const [hasScrolledToInitial, setHasScrolledToInitial] = useState(false);
+  const initialCursor = useRef<RecentActivityCursor>({
+    offset: Date.now(),
+    pageNum: 1,
+  });
+  const initialUnreadCount = useRef(parseUnreadCount(unreadCount));
 
-  const activeTab = normalizeStreamTab(type);
-
-  const { height: screenHeight } = useWindowDimensions();
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
-  const [isSharing, setIsSharing] = useState(false);
-  const [selectedAnswer, setSelectedAnswer] =
-    useState<StreamContentItem | null>(null);
-
-  const footerAnim = useSharedValue(0);
-  const isFloatingShown = useRef(false);
-  const lastCheckTime = useRef(0);
-  const itemRefs = useRef(new Map<string, StreamItemHandle | null>());
-  const itemLayouts = useRef(new Map<string, { y: number; height: number }>());
-  const [highlightedId, setHighlightedId] = useState<string | null>(null);
-
-  const [activeItem, setActiveItem] = useState<StreamContentItem | null>(null);
-  const viewableIdsRef = useRef<string[]>([]);
-  const viewabilityConfig = useRef({
-    viewAreaCoveragePercentThreshold: 20,
-  }).current;
-
-  const onViewableItemsChanged = useRef(
-    ({ viewableItems }: { viewableItems: ViewToken<StreamApiItem>[] }) => {
-      const ids: string[] = [];
-      let firstActive: StreamContentItem | null = null;
-
-      viewableItems.forEach((viewToken) => {
-        if (viewToken.item) {
-          const displayItem = getDisplayItem(viewToken.item, activeTab);
-          if (displayItem) {
-            const idStr = displayItem.id.toString();
-            ids.push(idStr);
-            if (!firstActive) {
-              firstActive = displayItem;
-            }
-          }
-        }
-      });
-
-      viewableIdsRef.current = ids;
-      if (firstActive) {
-        setActiveItem(firstActive);
-      }
-    },
-  ).current;
-
-  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    const currentY = event.nativeEvent.contentOffset.y;
-    const now = Date.now();
-
-    if (now - lastCheckTime.current > 50) {
-      lastCheckTime.current = now;
-
-      if (activeItem?.id && expandedIds.has(activeItem.id.toString())) {
-        const layout = itemLayouts.current.get(activeItem.id.toString());
-        if (layout) {
-          const headerHeight = 56;
-          const viewportHeight =
-            screenHeight - headerHeight - insets.top - insets.bottom;
-          const footerRelY = layout.y + layout.height - currentY;
-
-          // Footer is visible if its relative Y is within the viewport
-          const isFooterVisible =
-            footerRelY > 50 && footerRelY < viewportHeight - 20;
-          const shouldShow = !isFooterVisible && currentY > 300;
-
-          if (shouldShow !== isFloatingShown.current) {
-            isFloatingShown.current = shouldShow;
-            footerAnim.value = withSpring(shouldShow ? 1 : 0, {
-              damping: 18,
-              stiffness: 180,
-            });
-          }
-        }
-      } else {
-        if (isFloatingShown.current) {
-          isFloatingShown.current = false;
-          footerAnim.value = withSpring(0, {
-            damping: 18,
-            stiffness: 180,
-          });
-        }
-      }
-    }
-  };
-
-  const footerAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: footerAnim.value,
-    transform: [
-      {
-        translateY: 100 * (1 - footerAnim.value),
-      },
-    ],
-  }));
-
-  // 1. Fetch User Profile Details
   const {
-    data: user,
-    isLoading: isUserLoading,
-    isError: isUserError,
-    refetch: refetchUser,
+    data: member,
+    isLoading: isMemberLoading,
+    isError: isMemberError,
+    refetch: refetchMember,
   } = useQuery({
     queryKey: ['user-detail', id],
     queryFn: () => getMemberWithFallback(id),
   });
 
-  // 2. Infinite Query for specific content type stream
   const {
-    data: streamData,
-    isLoading: streamLoading,
+    data,
+    isLoading,
+    isError,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-    isError: isStreamError,
-    refetch: refetchStream,
+    refetch,
   } = useInfiniteQuery({
-    queryKey: ['user-stream', id, activeTab],
-    queryFn: ({ pageParam = 0 }) => {
-      const targetId = user?.url_token || id;
-      if (activeTab === 'activities') {
-        return getMemberActivities(targetId, 10, pageParam);
-      }
-
-      let include = '';
-      if (activeTab === 'answers') include = MEMBER_ANSWERS_INCLUDE;
-      else if (activeTab === 'questions')
-        include =
-          'data[*].created,data[*].answer_count,data[*].follower_count,data[*].author,data[*].admin_closed_comment,data[*].relationship.is_following';
-      else if (activeTab === 'articles')
-        include =
-          'data[*].comment_count,data[*].content,data[*].voteup_count,data[*].created,data[*].updated,data[*].title,data[*].excerpt,data[*].relationship.voting';
-      else if (activeTab === 'pins')
-        include =
-          'data[*].content,data[*].reaction_count,data[*].comment_count,data[*].created,data[*].relationship.voting';
-
-      return getMemberRelations(targetId, activeTab, {
-        include,
-        offset: pageParam,
-        limit: activeTab === 'answers' ? 20 : 10,
-        ...(activeTab === 'answers'
-          ? { sort_by: 'created', ws_qiangzhisafe: 0 }
-          : {}),
-      });
-    },
-    initialPageParam: 0,
+    queryKey: ['user-recent-published-activities', member?.id],
+    queryFn: ({ pageParam }) =>
+      getRecentMemberActivities(member?.id || '', pageParam),
+    initialPageParam: initialCursor.current,
     getNextPageParam: (lastPage) => {
-      if (!lastPage || lastPage.paging?.is_end) return undefined;
-      return getNextPageOffset(lastPage.paging?.next);
+      if (lastPage.paging?.is_end) return undefined;
+      return getNextRecentActivityCursor(lastPage.paging?.next);
     },
-    enabled: !!user,
+    enabled: !!member?.id,
   });
 
-  const streamItems =
-    streamData?.pages.flatMap((page) => page.data || []) || [];
-
-  // Scroll to clicked/initial item if found in loaded stream
-  useEffect(() => {
-    if (initialId && streamItems.length > 0 && !hasScrolledToInitial) {
-      const index = streamItems.findIndex((item) => {
-        const displayItem = getDisplayItem(item, activeTab);
-        return displayItem?.id.toString() === initialId.toString();
-      });
-      if (index !== -1) {
-        setHasScrolledToInitial(true);
-        setTimeout(() => {
-          flashListRef.current?.scrollToIndex({
-            index,
-            animated: true,
-            viewPosition: 0,
-          });
-        }, 300);
-      }
-    }
-  }, [streamItems, initialId, hasScrolledToInitial, activeTab]);
-
-  const handleToggleExpand = useCallback(
-    (id: string, expanded: boolean) => {
-      if (
-        Platform.OS === 'android' &&
-        UIManager.setLayoutAnimationEnabledExperimental
-      ) {
-        UIManager.setLayoutAnimationEnabledExperimental(true);
-      }
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-
-      setExpandedIds((prev) => {
-        const next = new Set(prev);
-        if (expanded) next.add(id);
-        else next.delete(id);
-        return next;
-      });
-
-      if (!expanded) {
-        setHighlightedId(id);
-        setTimeout(() => {
-          setHighlightedId((current) => (current === id ? null : current));
-        }, 1500);
-
-        // Collapsing: scroll back to the item to prevent losing context
-        setTimeout(() => {
-          const index = streamItems.findIndex(
-            (item) => getDisplayItem(item, activeTab)?.id.toString() === id,
-          );
-          if (index >= 0) {
-            flashListRef.current?.scrollToIndex({
-              index: index,
-              animated: true,
-              viewOffset: insets.top + 56,
-            });
-          }
-        }, 100);
-      }
-    },
-    [streamItems, activeTab, insets.top],
+  const activities = data?.pages.flatMap((page) => page.data) || [];
+  const isEnd = data?.pages.at(-1)?.paging?.is_end ?? false;
+  const readBoundary = getRecentActivityReadBoundary(
+    initialUnreadCount.current,
+    activities.length,
+    isEnd,
   );
+  const rows: PublishedStreamRow[] = [];
 
-  const renderItemContent = ({ item }: ListRenderItemInfo<StreamApiItem>) => {
-    const displayItem = getDisplayItem(item, activeTab);
-    if (!displayItem) return null;
-
-    let itemType: 'answer' | 'article' | 'question' | 'pin' | 'video' =
-      'answer';
-    const typeStr = displayItem.type;
-    if (typeStr === 'article') itemType = 'article';
-    else if (typeStr === 'question') itemType = 'question';
-    else if (typeStr === 'pin') itemType = 'pin';
-    else if (typeStr === 'zvideo' || typeStr === 'video') itemType = 'video';
-
-    const isHighlighted =
-      initialId && displayItem.id?.toString() === initialId?.toString();
-
-    return (
-      <View
-        className="py-0.5 bg-transparent"
-        style={
-          isHighlighted && {
-            borderLeftWidth: 3,
-            borderLeftColor: primaryColor,
-          }
-        }
-        onLayout={(event) => {
-          const { y, height } = event.nativeEvent.layout;
-          if (displayItem?.id) {
-            itemLayouts.current.set(displayItem.id.toString(), { y, height });
-          }
-        }}
-      >
-        <StreamItem
-          ref={(r) => {
-            itemRefs.current.set(displayItem.id.toString(), r);
-          }}
-          item={displayItem}
-          type={itemType}
-          isExpanded={expandedIds.has(displayItem.id.toString())}
-          onToggle={handleToggleExpand}
-          onShare={(ans) => {
-            setSelectedAnswer(ans);
-            setIsSharing(true);
-          }}
-          isHighlighted={!!isHighlighted}
-          isCollapsedHighlighted={highlightedId === displayItem.id.toString()}
-        />
-      </View>
-    );
-  };
-
-  const getTypeName = () => {
-    if (activeTab === 'answers') return '回答';
-    if (activeTab === 'articles') return '文章';
-    if (activeTab === 'questions') return '提问';
-    if (activeTab === 'pins') return '想法';
-    return '动态';
-  };
+  if (member) {
+    activities.forEach((activity, index) => {
+      const item = toFeedItem(activity, member);
+      if (item) {
+        rows.push({
+          key: `published-${item.type}-${item.id}`,
+          kind: 'content',
+          item,
+        });
+      }
+      if (index + 1 === readBoundary) {
+        rows.push({ key: 'read-boundary', kind: 'read-boundary' });
+      }
+    });
+  }
 
   return (
     <View
-      type="default"
       className="flex-1"
-      style={{
-        backgroundColor: Colors[colorScheme].background,
-      }}
+      style={{ backgroundColor: Colors[colorScheme].background }}
     >
-      <Stack.Screen options={{ headerShown: false, title: '个人动态' }} />
-      {isUserLoading ? (
+      <Stack.Screen options={{ headerShown: false, title: '用户发布' }} />
+      <View
+        className="flex-row items-center px-4 pb-3 border-b border-black/5 dark:border-white/5"
+        style={{ paddingTop: insets.top + 10 }}
+      >
+        <BouncyButton
+          onPress={() => router.back()}
+          className="w-9 h-9 items-center justify-center rounded-full mr-2"
+        >
+          <Ionicons
+            name="chevron-back"
+            size={24}
+            color={Colors[colorScheme].text}
+          />
+        </BouncyButton>
+        {member?.avatar_url ? (
+          <Image
+            source={{ uri: member.avatar_url }}
+            className="w-9 h-9 rounded-full mr-2.5"
+          />
+        ) : null}
+        <View className="flex-1 bg-transparent">
+          <Text className="font-bold text-[15px]" numberOfLines={1}>
+            {member?.name || '用户发布'}
+          </Text>
+          <Text type="secondary" className="text-[11px]">
+            最近发布
+          </Text>
+        </View>
+      </View>
+
+      {isMemberLoading ? (
         <View className="flex-1 items-center justify-center bg-transparent">
           <ActivityIndicator color={primaryColor} />
         </View>
-      ) : isUserError || !user ? (
+      ) : isMemberError || !member ? (
         <QueryErrorView
           message="用户资料加载失败"
-          onRetry={() => void refetchUser()}
+          onRetry={() => void refetchMember()}
         />
       ) : (
-        <>
-          {/* 1. Header Bar */}
-          <View
-            className="flex-row items-center px-4 py-3 border-b border-gray-100 dark:border-gray-800"
-            style={{
-              paddingTop: insets.top,
-              backgroundColor: Colors[colorScheme].background,
-            }}
-          >
-            <BouncyButton
-              onPress={() => router.back()}
-              className="p-1 -ml-1 bg-transparent"
-            >
-              <Ionicons
-                name="chevron-back"
-                size={24}
-                color={Colors[colorScheme].text}
-              />
-            </BouncyButton>
-
-            {/* User Mini Profile */}
-            <BouncyButton
-              onPress={() => router.push(`/user/${user?.url_token || id}`)}
-              className="flex-row items-center ml-2 flex-1 bg-transparent"
-            >
-              <Image
-                source={{
-                  uri:
-                    user?.avatar_url ||
-                    'https://picx.zhimg.com/v2-abed1a8c04702bc9e7ba3d3d82bc7591_l.jpg',
-                }}
-                className="w-8 h-8 rounded-full"
-              />
-              <View className="ml-2 bg-transparent flex-1">
-                <Text className="font-bold text-sm" numberOfLines={1}>
-                  {user?.name || '加载中...'}
+        <FlashList<PublishedStreamRow>
+          data={rows}
+          keyExtractor={(row) => row.key}
+          renderItem={({ item: row }) =>
+            row.kind === 'content' ? (
+              <FeedCard item={row.item} />
+            ) : (
+              <View className="flex-row items-center mx-4 my-5 bg-transparent">
+                <View className="flex-1 h-px bg-black/10 dark:bg-white/10" />
+                <Text type="secondary" className="mx-3 text-xs">
+                  已看完本次更新
                 </Text>
-                <Text
-                  type="secondary"
-                  className="text-[11px]"
-                  numberOfLines={1}
-                >
-                  {user?.headline || '查看全部个人主页'}
-                </Text>
+                <View className="flex-1 h-px bg-black/10 dark:bg-white/10" />
               </View>
-            </BouncyButton>
-
-            {/* Content Type Badge */}
-            <View
-              className="px-2.5 py-1 rounded-full ml-2"
-              style={{ backgroundColor: 'rgba(0,132,255,0.08)' }}
-            >
-              <Text type="primary" className="text-xs font-bold">
-                {getTypeName()}流
+            )
+          }
+          contentContainerStyle={{ paddingVertical: 10, paddingBottom: 50 }}
+          onEndReached={() => {
+            if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
+          }}
+          onEndReachedThreshold={0.5}
+          ListEmptyComponent={
+            isLoading ? (
+              <ActivityIndicator
+                style={{ marginTop: 100 }}
+                color={primaryColor}
+              />
+            ) : isError ? (
+              <QueryErrorView
+                message="发布内容加载失败"
+                onRetry={() => void refetch()}
+              />
+            ) : (
+              <Text type="secondary" className="text-center mt-20 text-sm">
+                暂无发布内容
               </Text>
-            </View>
-          </View>
-
-          {/* 2. Content Stream List */}
-          <FlashList<StreamApiItem>
-            ref={flashListRef}
-            onScroll={handleScroll}
-            data={streamItems}
-            keyExtractor={(item) => {
-              const displayItem = getDisplayItem(item, activeTab);
-              return `stream-${displayItem?.id ?? item.url ?? 'unknown'}`;
-            }}
-            renderItem={renderItemContent}
-            onViewableItemsChanged={onViewableItemsChanged}
-            viewabilityConfig={viewabilityConfig}
-            onEndReached={() => {
-              if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-            }}
-            onEndReachedThreshold={0.5}
-            contentContainerStyle={{ paddingVertical: 10, paddingBottom: 50 }}
-            ListEmptyComponent={
-              streamLoading ? (
-                <ActivityIndicator
-                  style={{ marginTop: 100 }}
-                  color={primaryColor}
-                />
-              ) : isStreamError ? (
-                <QueryErrorView
-                  message="内容流加载失败"
-                  onRetry={() => void refetchStream()}
-                />
-              ) : (
-                <Text type="secondary" className="text-center mt-20 text-sm">
-                  暂无内容流 喵~
-                </Text>
-              )
-            }
-            ListFooterComponent={
-              isFetchingNextPage ? (
-                <ActivityIndicator
-                  style={{ margin: 20 }}
-                  color={primaryColor}
-                />
-              ) : streamItems.length > 0 && !hasNextPage ? (
-                <Text type="secondary" className="text-center p-5 text-xs">
-                  — 已经到底了喵 —
-                </Text>
-              ) : null
-            }
-          />
-
-          <ShareMenu
-            visible={isSharing}
-            onClose={() => {
-              setIsSharing(false);
-              setSelectedAnswer(null);
-            }}
-            type={
-              selectedAnswer?.type === 'article'
-                ? 'article'
-                : selectedAnswer?.type === 'pin'
-                  ? 'pin'
-                  : selectedAnswer?.type === 'question'
-                    ? 'question'
-                    : selectedAnswer?.type === 'zvideo' ||
-                        selectedAnswer?.type === 'video'
-                      ? 'video'
-                      : 'answer'
-            }
-            data={
-              selectedAnswer
-                ? {
-                    id: selectedAnswer.id,
-                    title:
-                      selectedAnswer.title ||
-                      selectedAnswer.question?.title ||
-                      '想法',
-                    author: selectedAnswer.author?.name || user?.name,
-                    authorHeadline:
-                      selectedAnswer.author?.headline || user?.headline,
-                    content:
-                      selectedAnswer.excerpt ||
-                      (typeof selectedAnswer.content === 'string'
-                        ? selectedAnswer.content
-                        : ''),
-                  }
-                : null
-            }
-          />
-
-          <Reanimated.View
-            className="absolute left-5 right-5 h-[54px] rounded-[27px] overflow-hidden z-[1000]"
-            style={[
-              {
-                bottom: insets.bottom,
-              },
-              colorScheme === 'light' && {
-                shadowColor: Colors.light.shadow,
-                shadowOffset: { width: 0, height: 10 },
-                shadowOpacity: 0.2,
-                shadowRadius: 15,
-                elevation: 10,
-              },
-              footerAnimatedStyle,
-            ]}
-          >
-            <BlurView
-              intensity={95}
-              tint={colorScheme}
-              className="flex-1"
-              style={{
-                backgroundColor:
-                  colorScheme === 'dark'
-                    ? 'rgba(26,26,26,0.8)'
-                    : 'rgba(255,255,255,0.85)',
-              }}
-            >
-              <View className="flex-1 flex-row items-center px-5 justify-between bg-transparent">
-                <View className="flex-row items-center bg-transparent">
-                  {activeItem && (
-                    <LikeButton
-                      id={activeItem.id}
-                      count={
-                        activeItem.reaction?.statistics?.like_count ||
-                        activeItem.voteup_count ||
-                        activeItem.reaction_count ||
-                        0
-                      }
-                      voted={activeItem.relationship?.voting || 0}
-                      type={
-                        activeItem.type === 'article'
-                          ? 'articles'
-                          : activeItem.type === 'pin'
-                            ? 'pins'
-                            : 'answers'
-                      }
-                      variant="ghost"
-                    />
-                  )}
-                  <BouncyButton
-                    className="flex-row items-center justify-center ml-3 p-2 rounded-full bg-transparent"
-                    onPress={() => {
-                      const commentType =
-                        activeItem?.type === 'article'
-                          ? 'article'
-                          : activeItem?.type === 'pin'
-                            ? 'pin'
-                            : 'answer';
-                      router.push(
-                        `/comments/${activeItem?.id}?type=${commentType}&count=${activeItem?.comment_count || 0}`,
-                      );
-                    }}
-                  >
-                    <Ionicons
-                      name="chatbubble-outline"
-                      size={20}
-                      color={primaryColor}
-                    />
-                    <Text
-                      type="primary"
-                      className=" text-sm font-bold"
-                      style={{ color: primaryColor }}
-                    >
-                      {activeItem?.comment_count || 0}
-                    </Text>
-                  </BouncyButton>
-
-                  {activeItem?.id &&
-                    expandedIds.has(activeItem.id.toString()) && (
-                      <BouncyButton
-                        className="flex-row items-center justify-center ml-3 p-2 rounded-full bg-transparent"
-                        onPress={() =>
-                          handleToggleExpand(activeItem.id.toString(), false)
-                        }
-                      >
-                        <Ionicons
-                          name="chevron-up-circle-outline"
-                          size={20}
-                          color={primaryColor}
-                        />
-                        <Text
-                          type="primary"
-                          className=" text-sm font-bold"
-                          style={{ color: primaryColor }}
-                        >
-                          收起
-                        </Text>
-                      </BouncyButton>
-                    )}
-                </View>
-                <BouncyButton
-                  className="flex-row items-center justify-center p-2 rounded-full bg-transparent"
-                  onPress={() => {
-                    setSelectedAnswer(activeItem);
-                    setIsSharing(true);
-                  }}
-                >
-                  <Ionicons
-                    name="share-outline"
-                    size={22}
-                    color={primaryColor}
-                  />
-                </BouncyButton>
-              </View>
-            </BlurView>
-          </Reanimated.View>
-        </>
+            )
+          }
+          ListFooterComponent={
+            isFetchingNextPage ? (
+              <ActivityIndicator style={{ margin: 20 }} color={primaryColor} />
+            ) : rows.length > 0 && !hasNextPage ? (
+              <Text type="secondary" className="text-center p-5 text-xs">
+                — 已经到底了喵 —
+              </Text>
+            ) : null
+          }
+        />
       )}
     </View>
   );

--- a/components/RecentMoments.tsx
+++ b/components/RecentMoments.tsx
@@ -1,7 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
 import { Image, Pressable, ScrollView } from 'react-native';
-import { fetchRecentMoments } from '@/api/zhihu';
+import {
+  fetchRecentMoments,
+  markRecentMomentsRead,
+  type RecentMomentItem,
+  type RecentMomentsResponse,
+} from '@/api/zhihu';
 import { Text, useThemeColor, View } from './Themed';
 import { useColorScheme } from './useColorScheme';
 
@@ -10,6 +15,7 @@ import { useColorScheme } from './useColorScheme';
  */
 export function RecentMoments() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const _colorScheme = useColorScheme();
   const primaryColor = useThemeColor({}, 'primary');
   const dangerColor = useThemeColor({}, 'danger');
@@ -28,6 +34,52 @@ export function RecentMoments() {
     return null;
   }
 
+  const markReadOnPress = (item: RecentMomentItem) => {
+    const readToken = item.brief || item.id;
+    if (item.unread_count <= 0 || !readToken) return;
+
+    queryClient.setQueryData<RecentMomentsResponse>(
+      ['recent-moments'],
+      (current) =>
+        current
+          ? {
+              ...current,
+              data: current.data.map((currentItem) =>
+                currentItem.actor.id === item.actor.id
+                  ? { ...currentItem, unread_count: 0 }
+                  : currentItem,
+              ),
+            }
+          : current,
+    );
+
+    const restoreUnreadCount = () => {
+      queryClient.setQueryData<RecentMomentsResponse>(
+        ['recent-moments'],
+        (current) =>
+          current
+            ? {
+                ...current,
+                data: current.data.map((currentItem) =>
+                  currentItem.actor.id === item.actor.id
+                    ? { ...currentItem, unread_count: item.unread_count }
+                    : currentItem,
+                ),
+              }
+            : current,
+      );
+    };
+
+    void markRecentMomentsRead(readToken)
+      .then((result) => {
+        if (!result.success) restoreUnreadCount();
+      })
+      .catch(() => {
+        restoreUnreadCount();
+        console.warn('标记最近动态已读失败');
+      });
+  };
+
   return (
     <View className="bg-transparent border-b-[0.5px] border-black/5 dark:border-white/5">
       <ScrollView
@@ -38,12 +90,16 @@ export function RecentMoments() {
         {data.data.map((item) => (
           <Pressable
             key={item.actor.id}
-            onPress={() =>
+            onPress={() => {
+              markReadOnPress(item);
               router.push({
-                pathname: `/user/${item.actor.url_token || item.actor.id}/stream`,
-                params: { type: 'answers' },
-              } as any)
-            }
+                pathname: '/user/[id]/stream',
+                params: {
+                  id: item.actor.url_token || item.actor.id,
+                  unreadCount: String(item.unread_count),
+                },
+              });
+            }}
             className="items-center mr-4 w-[64px]"
           >
             <View className="relative mb-1.5 bg-transparent">

--- a/tests/userProfile.test.mjs
+++ b/tests/userProfile.test.mjs
@@ -3,6 +3,9 @@ import test from 'node:test';
 import { parseZhihuUrl } from '../utils/url.ts';
 import {
   getNextPageOffset,
+  getNextRecentActivityCursor,
+  getRecentActivityReadBoundary,
+  getRecentActivityTargetId,
   isOwnMemberProfile,
   isSameMember,
   normalizeUserFeedType,
@@ -38,6 +41,7 @@ test('does not treat every loaded profile as the signed-in member', () => {
 test('normalizes profile content types without treating videos as answers', () => {
   assert.equal(normalizeUserFeedType('answer'), 'answers');
   assert.equal(normalizeUserFeedType('articles'), 'articles');
+  assert.equal(normalizeUserFeedType('moments_pin'), 'pins');
   assert.equal(normalizeUserFeedType('zvideo'), 'videos');
   assert.equal(normalizeUserFeedType('videos'), 'videos');
   assert.equal(normalizeUserFeedType('unsupported'), null);
@@ -55,6 +59,42 @@ test('reads pagination offsets through URLSearchParams', () => {
     undefined,
   );
   assert.equal(getNextPageOffset(undefined), undefined);
+});
+
+test('reads recent activity timestamp cursors and page numbers', () => {
+  assert.deepEqual(
+    getNextRecentActivityCursor(
+      'https://api.zhihu.com/moments/recent/people/member-id/activities?action=down&offset=1787412683057&page_num=2',
+    ),
+    { offset: 1787412683057, pageNum: 2 },
+  );
+  assert.equal(
+    getNextRecentActivityCursor(
+      '/moments/recent/people/member-id/activities?offset=1787412683057',
+    ),
+    undefined,
+  );
+  assert.equal(getNextRecentActivityCursor(undefined), undefined);
+});
+
+test('recovers exact oversized pin ids from activity URLs', () => {
+  assert.equal(
+    getRecentActivityTargetId({
+      id: 2077095966344327700,
+      type: 'moments_pin',
+      url: 'https://www.zhihu.com/pin/2077095966344327531?native=1',
+    }),
+    '2077095966344327531',
+  );
+  assert.equal(getRecentActivityTargetId({ id: 123, type: 'answer' }), 123);
+});
+
+test('places the read boundary using the entry-time unread snapshot', () => {
+  assert.equal(getRecentActivityReadBoundary(5, 7, false), 5);
+  assert.equal(getRecentActivityReadBoundary(9, 7, false), undefined);
+  assert.equal(getRecentActivityReadBoundary(9, 7, true), 7);
+  assert.equal(getRecentActivityReadBoundary(0, 7, true), undefined);
+  assert.equal(getRecentActivityReadBoundary(Number.NaN, 7, true), undefined);
 });
 
 test('normalizes public Zhihu video links to the internal video route', () => {

--- a/utils/userProfile.ts
+++ b/utils/userProfile.ts
@@ -75,6 +75,7 @@ export function normalizeUserFeedType(
       return 'questions';
     case 'pin':
     case 'pins':
+    case 'moments_pin':
       return 'pins';
     case 'video':
     case 'videos':
@@ -97,4 +98,67 @@ export function getNextPageOffset(nextUrl: string | null | undefined) {
   } catch {
     return undefined;
   }
+}
+
+export interface RecentActivityCursor {
+  offset: number;
+  pageNum: number;
+}
+
+interface RecentActivityTargetIdentity {
+  id?: string | number;
+  type?: string;
+  url?: string;
+}
+
+/** Recover exact pin ids from URLs because their JSON numbers exceed 2^53 - 1. */
+export function getRecentActivityTargetId(
+  target: RecentActivityTargetIdentity,
+) {
+  if (
+    !target.url ||
+    (target.type !== 'moments_pin' &&
+      target.type !== 'pin' &&
+      target.type !== 'pins')
+  ) {
+    return target.id;
+  }
+  try {
+    const pathname = new URL(target.url, 'https://www.zhihu.com').pathname;
+    return pathname.match(/^\/pins?\/([^/]+)$/)?.[1] || target.id;
+  } catch {
+    return target.id;
+  }
+}
+
+/** Parse the timestamp cursor used by the Android recent-person activity API. */
+export function getNextRecentActivityCursor(
+  nextUrl: string | null | undefined,
+): RecentActivityCursor | undefined {
+  if (!nextUrl) return undefined;
+  try {
+    const url = new URL(nextUrl, 'https://api.zhihu.com');
+    const offset = Number.parseInt(url.searchParams.get('offset') || '', 10);
+    const pageNum = Number.parseInt(url.searchParams.get('page_num') || '', 10);
+    if (!Number.isFinite(offset) || !Number.isFinite(pageNum)) return undefined;
+    return { offset, pageNum };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Return the raw activity index after which the entry-time unread marker goes.
+ * Keep waiting for more pages unless the server says the stream has ended.
+ */
+export function getRecentActivityReadBoundary(
+  unreadCount: number,
+  loadedCount: number,
+  isEnd: boolean,
+) {
+  if (!Number.isInteger(unreadCount) || unreadCount <= 0 || loadedCount <= 0) {
+    return undefined;
+  }
+  if (loadedCount >= unreadCount) return unreadCount;
+  return isEnd ? loadedCount : undefined;
 }


### PR DESCRIPTION
## Summary

- 接入 App 内用户最近发布内容接口，并使用 FeedCard 替换原 stream 页面实现
- 支持时间戳游标分页、进入时未读数量快照及“已看完本次更新”分界
- 点击最近更新头像时立即更新未读角标并上报已读，失败时回滚
- 修复 moments_pin 超大整数 ID 精度丢失导致的想法详情跳转错误
- 补充接口边界类型与分页、分界、想法 ID 测试

## Verification

- npm run check
- git diff --check

## Notes

- 未进行知乎 App 真机接口验证
- 全仓保留既有 121 条 Biome warning，本次改动文件无新增诊断