### PR TITLE
fix: handle API HTTP errors consistently

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -22,7 +22,17 @@ const apiClient = axios.create({
 const requestIds = new WeakMap<object, string>();
 let requestSequence = 0;
 const retriedRequests = new WeakSet<object>();
-const refreshPromises = new Map<string, Promise<boolean>>();
+
+interface SessionRefreshResult {
+  success: boolean;
+  invalidateSession: boolean;
+}
+
+const refreshPromises = new Map<string, Promise<SessionRefreshResult>>();
+
+export interface ApiRequestOptions {
+  signal?: AbortSignal;
+}
 
 function getSafePath(url?: string) {
   if (!url) return '<unknown>';
@@ -200,8 +210,12 @@ function persistResponseCookies(
   return mergedCookie;
 }
 
-async function performZhihuSessionRefresh(cookie: string): Promise<boolean> {
-  if (!hasAuthenticationCookie(cookie)) return false;
+async function performZhihuSessionRefresh(
+  cookie: string,
+): Promise<SessionRefreshResult> {
+  if (!hasAuthenticationCookie(cookie)) {
+    return { success: false, invalidateSession: false };
+  }
   const accountIndexAtStart = useAuthStore.getState().activeAccountIndex;
 
   const refreshClient = axios.create({
@@ -229,14 +243,16 @@ async function performZhihuSessionRefresh(cookie: string): Promise<boolean> {
     );
     const tokenCookie = persistResponseCookies(tokenResponse, cookie);
     if (useAuthStore.getState().activeAccountIndex !== accountIndexAtStart) {
-      return false;
+      return { success: false, invalidateSession: false };
     }
     const refreshToken = getStringField(tokenResponse.data, 'refresh_token');
-    if (!refreshToken) return false;
+    if (!refreshToken) {
+      return { success: false, invalidateSession: true };
+    }
     // Account switching can happen while the first refresh request is in
     // flight. Do not exchange the old account's token after that switch.
     if (useAuthStore.getState().activeAccountIndex !== accountIndexAtStart) {
-      return false;
+      return { success: false, invalidateSession: false };
     }
 
     const timestamp = Date.now();
@@ -273,21 +289,34 @@ async function performZhihuSessionRefresh(cookie: string): Promise<boolean> {
       },
     );
     if (useAuthStore.getState().activeAccountIndex !== accountIndexAtStart) {
-      return false;
+      return { success: false, invalidateSession: false };
     }
     const finalCookie = persistResponseCookies(
       oauthResponse,
       tokenCookie || cookie,
     );
-    return hasAuthenticationCookie(
-      useAuthStore.getState().cookies || finalCookie || tokenCookie || cookie,
-    );
-  } catch {
-    return false;
+    return {
+      success: hasAuthenticationCookie(
+        useAuthStore.getState().cookies || finalCookie || tokenCookie || cookie,
+      ),
+      invalidateSession: !hasAuthenticationCookie(
+        useAuthStore.getState().cookies || finalCookie || tokenCookie || cookie,
+      ),
+    };
+  } catch (error) {
+    const status = axios.isAxiosError(error)
+      ? error.response?.status
+      : undefined;
+    return {
+      success: false,
+      // A rejected refresh with 401/403 means the refresh token is no longer
+      // valid. Network errors and 5xx responses should leave the session alone.
+      invalidateSession: status === 401 || status === 403,
+    };
   }
 }
 
-function refreshZhihuSession(cookie: string): Promise<boolean> {
+function refreshZhihuSession(cookie: string): Promise<SessionRefreshResult> {
   const existing = refreshPromises.get(cookie);
   if (existing) return existing;
 
@@ -380,16 +409,26 @@ apiClient.interceptors.response.use(
     const requestId = getRequestId(error.config);
     const method = error.config?.method?.toUpperCase() || '<unknown>';
     const path = getSafePath(error.config?.url);
+    let sessionInvalidated = false;
     if (error.response?.status === 401) {
       const requestCookie = getHeaderValue(error.config?.headers, 'Cookie');
       if (error.config && requestCookie && !retriedRequests.has(error.config)) {
         retriedRequests.add(error.config);
-        if (await refreshZhihuSession(requestCookie)) {
+        const refreshResult = await refreshZhihuSession(requestCookie);
+        if (refreshResult.success) {
           return apiClient.request(error.config);
+        }
+        const authState = useAuthStore.getState();
+        if (
+          refreshResult.invalidateSession &&
+          authState.cookies === requestCookie
+        ) {
+          authState.updateActiveAccountCookies('');
+          sessionInvalidated = true;
+          console.warn(`⚠️ [API ${requestId}] 登录状态已失效，请重新登录`);
         }
       }
       persistResponseCookies(error.response, requestCookie);
-      console.warn(`⚠️ [API ${requestId}] ${method} ${path} Status: 401`);
     } else if (error.response) {
       persistResponseCookies(error.response);
     }
@@ -422,11 +461,12 @@ apiClient.interceptors.response.use(
       return Promise.reject(error); // 拦截 40352，不抛出红屏错误
     }
 
-    if (error.response?.status === 404) {
-      console.warn(`⚠️ [API ${requestId}] ${method} ${path} Status: 404`);
-    } else if (error.response?.status !== 401) {
-      console.error(
-        `❌ [API ${requestId}] ${method} ${path} Status: ${error.response?.status || 'network-error'}`,
+    const status = error.response?.status;
+    const shouldLogTransientFailure =
+      !status || status === 408 || status === 429 || status >= 500;
+    if (shouldLogTransientFailure && !sessionInvalidated) {
+      console.warn(
+        `⚠️ [API ${requestId}] ${method} ${path} Status: ${status || 'network-error'}`,
       );
     }
     return Promise.reject(error);

--- a/api/zhihu/chat.ts
+++ b/api/zhihu/chat.ts
@@ -1,4 +1,4 @@
-import client from '../client';
+import client, { type ApiRequestOptions } from '../client';
 
 export interface ChatParticipant {
   type: string;
@@ -57,17 +57,26 @@ export interface ChatMessagesResponse {
   };
 }
 
-export const getInbox = async (nextUrl?: string) => {
+export const getInbox = async (
+  nextUrl?: string,
+  options: ApiRequestOptions = {},
+) => {
   const url = nextUrl || 'https://www.zhihu.com/api/v4/inbox';
-  const { data } = await client.get<InboxResponse>(url);
+  const { data } = await client.get<InboxResponse>(url, {
+    signal: options.signal,
+  });
   return data;
 };
 
-export const getMessages = async (senderId: string, nextUrl?: string) => {
+export const getMessages = async (
+  senderId: string,
+  nextUrl?: string,
+  options: ApiRequestOptions = {},
+) => {
   const url =
     nextUrl ||
     `https://www.zhihu.com/api/v4/chat?sender_id=${senderId}&limit=20`;
-  const { data } = await client.get<any>(url);
+  const { data } = await client.get<any>(url, { signal: options.signal });
 
   // 转换数据结构，使其与 POST 返回的单条消息结构一致，方便统一渲染
   const messages = data?.data?.messages || [];

--- a/api/zhihu/feed.ts
+++ b/api/zhihu/feed.ts
@@ -1,8 +1,8 @@
-import type { AxiosResponse } from 'axios';
+import axios, { type AxiosResponse } from 'axios';
 import type { ReactNode } from 'react';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useSettingsStore } from '@/store/useSettingsStore';
-import apiClient from '../client';
+import apiClient, { type ApiRequestOptions } from '../client';
 import {
   buildZhihuAppMomentsUrl,
   buildZhihuAppRecommendUrl,
@@ -604,7 +604,10 @@ export function buildRecommendRequestUrl(
   }
 }
 
-export const getFeed = async (url: string): Promise<ZhihuFeedResponse> => {
+export const getFeed = async (
+  url: string,
+  options: ApiRequestOptions = {},
+): Promise<ZhihuFeedResponse> => {
   let finalUrl = url;
   const { cookies } = useAuthStore.getState();
   const isRefreshRequest = url.includes('action=up') || url.includes('t=');
@@ -630,7 +633,9 @@ export const getFeed = async (url: string): Promise<ZhihuFeedResponse> => {
     try {
       const sectionsRes = await apiClient.get<{
         data?: Array<{ section_id?: string; section_name?: string }>;
-      }>('https://api.zhihu.com/feed-root/sections/query/v2');
+      }>('https://api.zhihu.com/feed-root/sections/query/v2', {
+        signal: options.signal,
+      });
       const sections = sectionsRes.data?.data || [];
       const localSection = sections.find(
         (section) =>
@@ -647,7 +652,8 @@ export const getFeed = async (url: string): Promise<ZhihuFeedResponse> => {
       } else {
         throw new Error('未找到同城版块');
       }
-    } catch {
+    } catch (error) {
+      if (axios.isCancel(error)) throw error;
       console.warn('获取同城版块失败，回退到推荐流');
       finalUrl = FEED_URLS.recommend;
     }
@@ -675,8 +681,10 @@ export const getFeed = async (url: string): Promise<ZhihuFeedResponse> => {
   try {
     res = await apiClient.get<ZhihuFeedResponse>(finalUrl, {
       headers: getZhihuAppEndpointHeaders(finalUrl),
+      signal: options.signal,
     });
   } catch (error) {
+    if (axios.isCancel(error)) throw error;
     // Some installs may not yet have all device credentials that the App
     // endpoint expects. Keep the previous browser guest feed as a
     // compatibility fallback instead of leaving a first-time user with no feed.
@@ -684,7 +692,9 @@ export const getFeed = async (url: string): Promise<ZhihuFeedResponse> => {
     let fallbackUrl =
       'https://www.zhihu.com/api/v3/explore/guest/feeds?limit=15&ws_qiangzhisafe=0';
     if (isRefreshRequest) fallbackUrl += `&t=${Date.now()}`;
-    res = await apiClient.get<ZhihuFeedResponse>(fallbackUrl);
+    res = await apiClient.get<ZhihuFeedResponse>(fallbackUrl, {
+      signal: options.signal,
+    });
   }
 
   if (url.startsWith('zhihu://local-feed')) {

--- a/api/zhihu/history.ts
+++ b/api/zhihu/history.ts
@@ -1,4 +1,8 @@
-import apiClient from '../client';
+import { useAuthStore } from '@/store/useAuthStore';
+import apiClient, {
+  type ApiRequestOptions,
+  hasAuthenticationCookie,
+} from '../client';
 
 export const CONTENT_TYPES = [
   'answer',
@@ -61,9 +65,17 @@ export interface ReadHistoryResponse {
 }
 
 export const addReadHistory = async (payload: AddReadHistoryPayload) => {
+  if (!hasAuthenticationCookie(useAuthStore.getState().cookies)) return null;
   const res = await apiClient.post('/read_history/add', payload);
   return res.data;
 };
+
+/** Best-effort background recording; reading content must not create an unhandled rejection. */
+export function recordReadHistory(payload: AddReadHistoryPayload): void {
+  void addReadHistory(payload).catch(() => {
+    console.warn('记录浏览历史失败');
+  });
+}
 
 export interface BatchDelReadHistoryPayload {
   pairs?: AddReadHistoryPayload[];
@@ -80,9 +92,11 @@ export const batchDelReadHistory = async (
 export const getReadHistory = async (
   limit = 20,
   offset = 0,
+  options: ApiRequestOptions = {},
 ): Promise<ReadHistoryResponse> => {
   const res = await apiClient.get<ReadHistoryResponse>(
     `/unify-consumption/read_history?limit=${limit}&offset=${offset}`,
+    { signal: options.signal },
   );
   return res.data;
 };

--- a/api/zhihu/image.ts
+++ b/api/zhihu/image.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { CryptoDigestAlgorithm, digest } from 'expo-crypto';
 import * as FileSystem from 'expo-file-system/legacy';
 import apiClient from '../client';
@@ -278,6 +279,19 @@ async function getImageAfterUpload(
       return await getImage(imageId);
     } catch (error) {
       lastError = error;
+      const isPendingProcessing =
+        error instanceof Error && error.message === '知乎图片尚未处理完成';
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+      const isTransientRequestError =
+        axios.isAxiosError(error) &&
+        !axios.isCancel(error) &&
+        (status === undefined ||
+          status === 408 ||
+          status === 429 ||
+          status >= 500);
+      if (!isPendingProcessing && !isTransientRequestError) throw error;
       if (attempt === 7) break;
       await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
     }

--- a/api/zhihu/notification.ts
+++ b/api/zhihu/notification.ts
@@ -1,12 +1,13 @@
-import apiClient from '../client';
+import apiClient, { type ApiRequestOptions } from '../client';
 
 export const getNotifications = async (
   nextUrl?: string,
   entryName: string = 'all',
+  options: ApiRequestOptions = {},
 ) => {
   const url =
     nextUrl || `/notifications/v2/recent?limit=10&entry_name=${entryName}`;
-  const res = await apiClient.get(url);
+  const res = await apiClient.get(url, { signal: options.signal });
   return res.data;
 };
 

--- a/api/zhihu/search.ts
+++ b/api/zhihu/search.ts
@@ -1,9 +1,13 @@
 import type { ZhihuSearchResponse } from '../../types/zhihu';
-import apiClient from '../client';
+import apiClient, { type ApiRequestOptions } from '../client';
 
-export const getSearchSuggest = async (query: string) => {
+export const getSearchSuggest = async (
+  query: string,
+  options: ApiRequestOptions = {},
+) => {
   const res = await apiClient.get(
     `/search/suggest?q=${encodeURIComponent(query)}`,
+    { signal: options.signal },
   );
   return res.data;
 };
@@ -26,6 +30,7 @@ export const searchContent = async (
       | 'three_months'
       | 'half_a_year'
       | 'a_year';
+    signal?: AbortSignal;
   },
 ): Promise<ZhihuSearchResponse> => {
   const params = new URLSearchParams({
@@ -59,7 +64,9 @@ export const searchContent = async (
   if (options?.restricted_value)
     params.append('restricted_value', options.restricted_value);
 
-  const res = await apiClient.get(`/search_v3?${params.toString()}`);
+  const res = await apiClient.get(`/search_v3?${params.toString()}`, {
+    signal: options?.signal,
+  });
   return res.data;
 };
 

--- a/api/zhihu/topic.ts
+++ b/api/zhihu/topic.ts
@@ -1,4 +1,4 @@
-import apiClient from '../client';
+import apiClient, { type ApiRequestOptions } from '../client';
 
 export const TOPIC_INCLUDE =
   'introduction,questions_count,best_answers_count,followers_count,is_following,header_card';
@@ -12,6 +12,7 @@ export const getTopicFeed = async (
   id: string | number,
   type: string = 'hot',
   offset: number = 0,
+  options: ApiRequestOptions = {},
 ) => {
   const typeMapping: Record<string, string> = {
     hot: 'hot',
@@ -23,6 +24,7 @@ export const getTopicFeed = async (
     'data[*].target.content,voteup_count,comment_count,author.name,author.avatar_url,author.headline,author.is_following,relationship.voting,relationship.is_author,created_time,segment_infos';
   const res = await apiClient.get(
     `/topics/${id}/feeds/${feedType}?include=${include}&limit=20&offset=${offset}`,
+    { signal: options.signal },
   );
   return res.data;
 };

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -51,6 +51,7 @@ import { BouncyButton } from '@/components/BouncyButton';
 import { DailyList } from '@/components/DailyList';
 import { FeedCard } from '@/components/FeedCard';
 import { HotCard, type HotItem } from '@/components/HotCard';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { RecentMoments } from '@/components/RecentMoments';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
@@ -1053,59 +1054,56 @@ const FeedList = React.forwardRef<
       hasNextPage,
       isFetchingNextPage,
       isLoading,
+      isError,
       isRefetching,
       refetch,
     } = useInfiniteQuery({
       queryKey: feedQueryKey,
-      queryFn: async ({ pageParam = FEED_URLS[tab] }) => {
-        try {
-          let requestUrl = pageParam as string;
-          const isInitialUrl =
-            (requestUrl === FEED_URLS[tab] ||
-              requestUrl === 'zhihu://local-feed' ||
-              requestUrl.includes('feed/topstory/recommend')) &&
-            !requestUrl.includes('action=down');
-          if (isRefreshing && isInitialUrl) {
-            const sep = requestUrl.includes('?') ? '&' : '?';
-            requestUrl = `${requestUrl}${sep}action=up&t=${Date.now()}`;
-          }
-
-          console.log(
-            `🌐 [queryFn] Requesting feed (tab=${tab}, isRefreshing=${isRefreshing})`,
-          );
-          const data = await getFeed(requestUrl);
-          const rawItems = data.data || [];
-          seedAnswerDetailsFromFeed(queryClient, rawItems);
-          let items: Array<FeedItem | HotItem>;
-          if (tab === 'following')
-            items = rawItems
-              .map((item: RawFeedItem) => parseFollowingData(item))
-              .filter(Boolean) as FeedItem[];
-          else if (tab === 'recommend' || tab === 'local')
-            items = rawItems
-              .map((item: RawFeedItem) => parseRecommendData(item))
-              .filter(Boolean) as FeedItem[];
-          else
-            items = rawItems.map((item: RawFeedItem, index: number) =>
-              parseHotData(item, index),
-            );
-
-          const nextUrl =
-            data.paging?.next?.replace('http://', 'https://') ?? null;
-
-          if (launchCacheContext && isInitialUrl && items.length > 0) {
-            void feedCacheRepository
-              .saveFeedCache(launchCacheContext, items, nextUrl)
-              .catch((err) => console.warn('保存启动 Feed 缓存失败', err));
-          }
-
-          return {
-            items,
-            nextUrl,
-          };
-        } catch {
-          return { items: [], nextUrl: null };
+      queryFn: async ({ pageParam = FEED_URLS[tab], signal }) => {
+        let requestUrl = pageParam as string;
+        const isInitialUrl =
+          (requestUrl === FEED_URLS[tab] ||
+            requestUrl === 'zhihu://local-feed' ||
+            requestUrl.includes('feed/topstory/recommend')) &&
+          !requestUrl.includes('action=down');
+        if (isRefreshing && isInitialUrl) {
+          const sep = requestUrl.includes('?') ? '&' : '?';
+          requestUrl = `${requestUrl}${sep}action=up&t=${Date.now()}`;
         }
+
+        console.log(
+          `🌐 [queryFn] Requesting feed (tab=${tab}, isRefreshing=${isRefreshing})`,
+        );
+        const data = await getFeed(requestUrl, { signal });
+        const rawItems = data.data || [];
+        seedAnswerDetailsFromFeed(queryClient, rawItems);
+        let items: Array<FeedItem | HotItem>;
+        if (tab === 'following')
+          items = rawItems
+            .map((item: RawFeedItem) => parseFollowingData(item))
+            .filter(Boolean) as FeedItem[];
+        else if (tab === 'recommend' || tab === 'local')
+          items = rawItems
+            .map((item: RawFeedItem) => parseRecommendData(item))
+            .filter(Boolean) as FeedItem[];
+        else
+          items = rawItems.map((item: RawFeedItem, index: number) =>
+            parseHotData(item, index),
+          );
+
+        const nextUrl =
+          data.paging?.next?.replace('http://', 'https://') ?? null;
+
+        if (launchCacheContext && isInitialUrl && items.length > 0) {
+          void feedCacheRepository
+            .saveFeedCache(launchCacheContext, items, nextUrl)
+            .catch((err) => console.warn('保存启动 Feed 缓存失败', err));
+        }
+
+        return {
+          items,
+          nextUrl,
+        };
       },
       initialPageParam: FEED_URLS[tab],
       getNextPageParam: (lastPage) => lastPage.nextUrl,
@@ -1373,6 +1371,11 @@ const FeedList = React.forwardRef<
             <View className="flex-1 items-center justify-center mt-[100px] bg-transparent">
               <ActivityIndicator size="large" color={tintColor} />
             </View>
+          ) : isError ? (
+            <QueryErrorView
+              message="Feed 加载失败"
+              onRetry={() => void refetch()}
+            />
           ) : (
             <View className="flex-1 items-center justify-center mt-[100px] bg-transparent">
               <Text type="secondary">暂无内容 喵~</Text>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -32,6 +32,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { resolveThemeColors } from '@/constants/theme';
 import { useSettingsStore } from '@/store/useSettingsStore';
 import { consumeAppClipboardText } from '@/utils/clipboard';
+import { shouldRetryQuery } from '@/utils/query';
 
 Sentry.init({
   dsn: 'https://93a6099dd49b040d9c516485eb3c72f6@o4511051860672512.ingest.de.sentry.io/4511051866112080',
@@ -62,14 +63,7 @@ SplashScreen.preventAutoHideAsync();
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: (failureCount, error: any) => {
-        // 如果是人机验证错误（40352），停止自动重试，等待弹窗加载
-        if (error?.response?.data?.error?.code === 40352) {
-          return false;
-        }
-        // 其他错误默认重试 2 次 (共三次尝试)
-        return failureCount < 2;
-      },
+      retry: shouldRetryQuery,
       // 这里的配置确保不会因为网络瞬间闪烁在验证期间反复弹窗
       retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
     },

--- a/app/answer/[id].tsx
+++ b/app/answer/[id].tsx
@@ -14,7 +14,7 @@ import Reanimated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import client from '@/api/client';
 import { getAnswer } from '@/api/zhihu';
-import { addReadHistory } from '@/api/zhihu/history';
+import { recordReadHistory } from '@/api/zhihu/history';
 import { AnswerDetailView } from '@/components/AnswerDetailView';
 import { BouncyButton } from '@/components/BouncyButton';
 import { ShareMenu } from '@/components/ShareMenu';
@@ -58,7 +58,7 @@ export default function AnswerDetailScreen() {
 
   useEffect(() => {
     if (enableBrowseHistory && initialId) {
-      addReadHistory({ content_token: initialId, content_type: 'answer' });
+      recordReadHistory({ content_token: initialId, content_type: 'answer' });
       recordedIds.current.add(initialId);
     }
   }, [enableBrowseHistory, initialId]);
@@ -182,7 +182,7 @@ export default function AnswerDetailScreen() {
       currentId &&
       !recordedIds.current.has(currentId)
     ) {
-      addReadHistory({ content_token: currentId, content_type: 'answer' });
+      recordReadHistory({ content_token: currentId, content_type: 'answer' });
       recordedIds.current.add(currentId);
     }
   }, [enableBrowseHistory, currentId]);

--- a/app/article/[id].tsx
+++ b/app/article/[id].tsx
@@ -16,12 +16,13 @@ import {
   getArticleColumnCard,
   unfollowColumn,
 } from '@/api/zhihu/column';
-import { addReadHistory } from '@/api/zhihu/history';
+import { recordReadHistory } from '@/api/zhihu/history';
 import { followMember, unfollowMember } from '@/api/zhihu/member';
 import { BouncyButton } from '@/components/BouncyButton';
 import { DownvoteButton } from '@/components/DownvoteButton';
 import { LikeButton } from '@/components/LikeButton';
 import { ActionSheet } from '@/components/overlays/ActionSheet';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { ShareMenu } from '@/components/ShareMenu';
 import { Text, ThemedIcon, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
@@ -53,7 +54,12 @@ export default function ArticleDetail() {
   const scrollY = useRef(new Animated.Value(0)).current;
 
   // 1. 获取日报详情
-  const { data: dailyData, isLoading: dailyLoading } = useQuery({
+  const {
+    data: dailyData,
+    isLoading: dailyLoading,
+    isError: dailyError,
+    refetch: refetchDaily,
+  } = useQuery({
     queryKey: ['daily-article', id],
     queryFn: () => getDailyDetail(id as string),
     enabled: source === 'daily',
@@ -62,7 +68,12 @@ export default function ArticleDetail() {
   });
 
   // 2. 获取知乎普通文章详情
-  const { data: zhihuData, isLoading: zhihuLoading } = useQuery({
+  const {
+    data: zhihuData,
+    isLoading: zhihuLoading,
+    isError: zhihuError,
+    refetch: refetchZhihu,
+  } = useQuery({
     queryKey: ['zhihu-article', id],
     queryFn: () => getArticle(id as string),
     enabled: source !== 'daily',
@@ -72,12 +83,17 @@ export default function ArticleDetail() {
 
   const isLoading = isDaily ? dailyLoading : zhihuLoading;
   const data = isDaily ? dailyData : zhihuData;
+  const isError = isDaily ? dailyError : zhihuError;
+  const refetchContent = isDaily ? refetchDaily : refetchZhihu;
 
   const enableBrowseHistory = useSettingsStore((s) => s.enableBrowseHistory);
 
   useEffect(() => {
     if (enableBrowseHistory && id) {
-      addReadHistory({ content_token: id as string, content_type: 'article' });
+      recordReadHistory({
+        content_token: id as string,
+        content_type: 'article',
+      });
     }
   }, [enableBrowseHistory, id]);
 
@@ -211,6 +227,17 @@ export default function ArticleDetail() {
   }
 
   if (!data) {
+    if (isError) {
+      return (
+        <View className="flex-1 justify-center items-center px-6">
+          <Stack.Screen options={{ headerShown: false, title: '正文' }} />
+          <QueryErrorView
+            message="正文加载失败"
+            onRetry={() => void refetchContent()}
+          />
+        </View>
+      );
+    }
     return (
       <View className="flex-1 justify-center items-center px-6">
         <Stack.Screen options={{ headerShown: false, title: '正文' }} />

--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -20,10 +20,13 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getMessages, sendMessage } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
 import { useAuthStore } from '@/store/useAuthStore';
+import { showToast } from '@/utils/toast';
+import { getZhihuErrorMessage } from '@/utils/zhihuError';
 
 export default function ChatScreen() {
   const { id, name } = useLocalSearchParams<{ id: string; name: string }>();
@@ -47,18 +50,26 @@ export default function ChatScreen() {
     });
   }, [navigation, name]);
 
-  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery({
-      queryKey: ['chat', id],
-      queryFn: ({ pageParam = '' }) => getMessages(id, pageParam as string),
-      initialPageParam: '',
-      getNextPageParam: (lastPage) => {
-        if (!lastPage || lastPage.paging?.is_end) return undefined;
-        return lastPage.paging?.next;
-      },
-      // Simple polling every 5 seconds
-      refetchInterval: 5000,
-    });
+  const {
+    data,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: ['chat', id],
+    queryFn: ({ pageParam = '', signal }) =>
+      getMessages(id, pageParam as string, { signal }),
+    initialPageParam: '',
+    getNextPageParam: (lastPage) => {
+      if (!lastPage || lastPage.paging?.is_end) return undefined;
+      return lastPage.paging?.next;
+    },
+    // Simple polling every 5 seconds
+    refetchInterval: 5000,
+  });
 
   const sendMutation = useMutation({
     mutationFn: (text: string) => sendMessage(id, text),
@@ -72,7 +83,8 @@ export default function ChatScreen() {
       queryClient.invalidateQueries({ queryKey: ['chat', id] });
     },
     onError: (err) => {
-      console.error('Failed to send message:', err);
+      console.error('发送消息失败');
+      showToast(getZhihuErrorMessage(err));
     },
   });
 
@@ -211,7 +223,18 @@ export default function ChatScreen() {
             ) : null
           }
           ListEmptyComponent={() =>
-            !isLoading ? (
+            !isLoading && isError ? (
+              <View
+                className="flex-1 items-center justify-center p-10 bg-transparent"
+                style={{ transform: [{ scaleY: -1 }] }}
+              >
+                <QueryErrorView
+                  compact
+                  message="聊天记录加载失败"
+                  onRetry={() => void refetch()}
+                />
+              </View>
+            ) : !isLoading ? (
               <View
                 className="flex-1 items-center justify-center p-10 bg-transparent"
                 style={{ transform: [{ scaleY: -1 }] }}

--- a/app/collections/[id].tsx
+++ b/app/collections/[id].tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { ActivityIndicator, StyleSheet } from 'react-native';
 import { getCollection, getCollectionDetail } from '@/api/zhihu';
 import { CreationCard } from '@/components/CreationCard';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
@@ -20,7 +21,11 @@ export default function CollectionDetailScreen() {
     navigation.setOptions({ title: '收藏夹' });
   }, [navigation]);
 
-  const { data: collection } = useQuery({
+  const {
+    data: collection,
+    isError: collectionError,
+    refetch: refetchCollection,
+  } = useQuery({
     queryKey: ['collection-detail', id],
     queryFn: () => getCollection(id as string),
   });
@@ -33,6 +38,7 @@ export default function CollectionDetailScreen() {
     isFetchingNextPage,
     refetch,
     isRefetching,
+    isError: contentsError,
   } = useInfiniteQuery({
     queryKey: ['collection-contents', id],
     queryFn: ({ pageParam = 0 }) =>
@@ -57,14 +63,24 @@ export default function CollectionDetailScreen() {
           borderBottomColor: borderColor,
         }}
       >
-        <Text className="text-xl font-bold">
-          {collection?.title || '收藏夹内容'}
-        </Text>
-        {collection?.description ? (
-          <Text type="secondary" className="text-sm mt-2.5 leading-5">
-            {collection.description}
-          </Text>
-        ) : null}
+        {collectionError ? (
+          <QueryErrorView
+            compact
+            message="收藏夹信息加载失败"
+            onRetry={() => void refetchCollection()}
+          />
+        ) : (
+          <>
+            <Text className="text-xl font-bold">
+              {collection?.title || '收藏夹内容'}
+            </Text>
+            {collection?.description ? (
+              <Text type="secondary" className="text-sm mt-2.5 leading-5">
+                {collection.description}
+              </Text>
+            ) : null}
+          </>
+        )}
       </View>
 
       <FlashList
@@ -87,6 +103,12 @@ export default function CollectionDetailScreen() {
           <View className="flex-1 p-[100px] items-center">
             {isLoading ? (
               <ActivityIndicator color={primaryColor} />
+            ) : contentsError ? (
+              <QueryErrorView
+                compact
+                message="收藏内容加载失败"
+                onRetry={() => void refetch()}
+              />
             ) : (
               <Text type="secondary">这个收藏夹空空如也喵</Text>
             )}

--- a/app/collections/index.tsx
+++ b/app/collections/index.tsx
@@ -18,9 +18,11 @@ import { BouncyButton } from '@/components/BouncyButton';
 import { CollectionEditorForm } from '@/components/CollectionEditorForm';
 import { ActionSheet } from '@/components/overlays/ActionSheet';
 import { BottomSheet } from '@/components/overlays/BottomSheet';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
+import { getZhihuErrorMessage } from '@/utils/zhihuError';
 
 interface CollectionItem {
   id: string | number;
@@ -54,6 +56,7 @@ export default function MyCollectionsScreen() {
     isFetchingNextPage,
     refetch,
     isRefetching,
+    isError,
   } = useInfiniteQuery({
     queryKey: ['my-collections'],
     queryFn: ({ pageParam = 0 }) => getMyCollections(20, pageParam as number),
@@ -72,6 +75,9 @@ export default function MyCollectionsScreen() {
       queryClient.invalidateQueries({ queryKey: ['my-collections'] });
       closeModal();
     },
+    onError: (error) => {
+      Alert.alert('创建失败', getZhihuErrorMessage(error));
+    },
   });
   const updateMutation = useMutation({
     mutationFn: (vars: {
@@ -82,11 +88,17 @@ export default function MyCollectionsScreen() {
       queryClient.invalidateQueries({ queryKey: ['my-collections'] });
       closeModal();
     },
+    onError: (error) => {
+      Alert.alert('保存失败', getZhihuErrorMessage(error));
+    },
   });
   const deleteMutation = useMutation({
     mutationFn: deleteCollection,
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ['my-collections'] }),
+    onError: (error) => {
+      Alert.alert('删除失败', getZhihuErrorMessage(error));
+    },
   });
 
   const openModal = useCallback((item?: CollectionItem) => {
@@ -233,6 +245,12 @@ export default function MyCollectionsScreen() {
           <View className="flex-1 p-[100px] items-center">
             {isLoading ? (
               <ActivityIndicator color={primaryColor} />
+            ) : isError ? (
+              <QueryErrorView
+                compact
+                message="收藏夹加载失败"
+                onRetry={() => void refetch()}
+              />
             ) : (
               <Text type="secondary">你还没有收藏夹喵</Text>
             )}

--- a/app/column/[id].tsx
+++ b/app/column/[id].tsx
@@ -11,8 +11,9 @@ import {
   getColumnItems,
   unfollowColumn,
 } from '@/api/zhihu/column';
-import { addReadHistory } from '@/api/zhihu/history';
+import { recordReadHistory } from '@/api/zhihu/history';
 import { BouncyButton } from '@/components/BouncyButton';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
@@ -32,7 +33,12 @@ export default function ColumnDetail() {
   const borderColor = useThemeColor({}, 'border');
 
   // 1. 获取专栏基本信息
-  const { data: column, isLoading: columnLoading } = useQuery({
+  const {
+    data: column,
+    isLoading: columnLoading,
+    isError: columnError,
+    refetch: refetchColumn,
+  } = useQuery({
     queryKey: ['column-detail', id],
     queryFn: () => getColumn(id),
   });
@@ -41,7 +47,7 @@ export default function ColumnDetail() {
 
   useEffect(() => {
     if (enableBrowseHistory && column?.id) {
-      addReadHistory({
+      recordReadHistory({
         content_token: String(column.id),
         content_type: 'column',
       });
@@ -72,6 +78,7 @@ export default function ColumnDetail() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isError: itemsError,
     refetch,
     isRefetching,
   } = useInfiniteQuery({
@@ -91,6 +98,15 @@ export default function ColumnDetail() {
   const renderHeader = () => {
     if (!column && columnLoading) {
       return <ActivityIndicator style={{ marginTop: 50 }} />;
+    }
+    if (!column && columnError) {
+      return (
+        <QueryErrorView
+          compact
+          message="专栏加载失败"
+          onRetry={() => void refetchColumn()}
+        />
+      );
     }
     if (!column) return null;
 
@@ -263,7 +279,17 @@ export default function ColumnDetail() {
         refreshing={isRefetching}
         ListEmptyComponent={() => (
           <View className="p-10 items-center bg-transparent">
-            {!itemsLoading && <Text type="secondary">专栏里还没有文章喵</Text>}
+            {itemsLoading ? (
+              <ActivityIndicator color={tintColor} />
+            ) : itemsError ? (
+              <QueryErrorView
+                compact
+                message="文章列表加载失败"
+                onRetry={() => void refetch()}
+              />
+            ) : (
+              <Text type="secondary">专栏里还没有文章喵</Text>
+            )}
           </View>
         )}
         ListFooterComponent={() =>

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -8,6 +8,7 @@ import {
 import { type Href, Stack, useRouter } from 'expo-router';
 import { useCallback, useState } from 'react';
 import { ActivityIndicator, Alert } from 'react-native';
+import { hasAuthenticationCookie } from '@/api/client';
 import {
   batchDelReadHistory,
   getReadHistory,
@@ -16,16 +17,21 @@ import {
   type ReadHistoryResponse,
 } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
+import { useAuthStore } from '@/store/useAuthStore';
 import { formatDate } from '@/utils/date';
+import { getZhihuErrorMessage } from '@/utils/zhihuError';
 
 export default function HistoryScreen() {
   const router = useRouter();
   const colorScheme = useColorScheme();
   const primaryColor = useThemeColor({}, 'primary');
   const queryClient = useQueryClient();
+  const cookies = useAuthStore((state) => state.cookies);
+  const isAuthenticated = hasAuthenticationCookie(cookies);
   const [selecting, setSelecting] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
@@ -37,9 +43,12 @@ export default function HistoryScreen() {
     isFetchingNextPage,
     refetch,
     isRefetching,
+    isError,
   } = useInfiniteQuery({
     queryKey: ['read-history'],
-    queryFn: ({ pageParam = 0 }) => getReadHistory(20, pageParam as number),
+    queryFn: ({ pageParam = 0, signal }) =>
+      getReadHistory(20, pageParam as number, { signal }),
+    enabled: isAuthenticated,
     initialPageParam: 0,
     getNextPageParam: (lastPage: ReadHistoryResponse) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
@@ -80,6 +89,9 @@ export default function HistoryScreen() {
       exitSelection();
       queryClient.invalidateQueries({ queryKey: ['read-history'] });
     },
+    onError: (error) => {
+      Alert.alert('删除失败', getZhihuErrorMessage(error));
+    },
   });
 
   const clearAllMutation = useMutation({
@@ -88,6 +100,9 @@ export default function HistoryScreen() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['read-history'] });
+    },
+    onError: (error) => {
+      Alert.alert('清空失败', getZhihuErrorMessage(error));
     },
   });
 
@@ -266,8 +281,16 @@ export default function HistoryScreen() {
         }
         ListEmptyComponent={() => (
           <View className="p-[50px] items-center">
-            {isLoading ? (
+            {!isAuthenticated ? (
+              <Text type="secondary">登录后才能查看浏览历史喵</Text>
+            ) : isLoading ? (
               <ActivityIndicator size="small" color={primaryColor} />
+            ) : isError ? (
+              <QueryErrorView
+                compact
+                message="浏览历史加载失败"
+                onRetry={() => void refetch()}
+              />
             ) : (
               <Text type="secondary">这里空空如也喵</Text>
             )}

--- a/app/inbox.tsx
+++ b/app/inbox.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect } from 'react';
 import { ActivityIndicator, Image, StyleSheet } from 'react-native';
 import { getInbox, type InboxThread } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
@@ -31,9 +32,11 @@ export default function InboxScreen() {
     isFetchingNextPage,
     refetch,
     isRefetching,
+    isError,
   } = useInfiniteQuery({
     queryKey: ['inbox'],
-    queryFn: ({ pageParam = '' }) => getInbox(pageParam as string),
+    queryFn: ({ pageParam = '', signal }) =>
+      getInbox(pageParam as string, { signal }),
     initialPageParam: '',
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
@@ -118,6 +121,12 @@ export default function InboxScreen() {
           <View className="flex-1 p-[100px] items-center">
             {isLoading ? (
               <ActivityIndicator color={primaryColor} />
+            ) : isError ? (
+              <QueryErrorView
+                compact
+                message="私信加载失败"
+                onRetry={() => void refetch()}
+              />
             ) : (
               <Text type="secondary">暂无私信</Text>
             )}

--- a/app/login/index.tsx
+++ b/app/login/index.tsx
@@ -145,7 +145,14 @@ export default function LoginScreen() {
         }}
         onNavigationStateChange={(navState) => {
           const { url } = navState;
-          console.log('🌐 导航至:', url);
+          let safeUrl = url.split('?')[0];
+          try {
+            const parsedUrl = new URL(url);
+            safeUrl = `${parsedUrl.origin}${parsedUrl.pathname}`;
+          } catch {
+            // Keep only the URL path when navigation reports a non-standard URL.
+          }
+          console.log('🌐 导航至:', safeUrl);
           if (
             url === 'https://www.zhihu.com/' ||
             url === 'https://www.zhihu.com'

--- a/app/notifications/index.tsx
+++ b/app/notifications/index.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Image, ScrollView, StyleSheet } from 'react-native';
 import { getNotifications, markAllNotificationsRead } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
@@ -59,10 +60,11 @@ export default function NotificationScreen() {
     isFetchingNextPage,
     refetch,
     isRefetching,
+    isError,
   } = useInfiniteQuery({
     queryKey: ['notifications', selectedType],
-    queryFn: ({ pageParam = '' }) =>
-      getNotifications(pageParam as string, selectedType),
+    queryFn: ({ pageParam = '', signal }) =>
+      getNotifications(pageParam as string, selectedType, { signal }),
     initialPageParam: '',
     getNextPageParam: (lastPage) => {
       if (!lastPage || lastPage.paging?.is_end) return undefined;
@@ -277,6 +279,12 @@ export default function NotificationScreen() {
           <View className="flex-1 p-[100px] items-center">
             {isLoading ? (
               <ActivityIndicator color={primaryColor} />
+            ) : isError ? (
+              <QueryErrorView
+                compact
+                message="通知加载失败"
+                onRetry={() => void refetch()}
+              />
             ) : (
               <Text type="secondary">暂无通知喵</Text>
             )}

--- a/app/pin/[id].tsx
+++ b/app/pin/[id].tsx
@@ -11,11 +11,12 @@ import {
   StyleSheet,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { addReadHistory } from '@/api/zhihu/history';
+import { recordReadHistory } from '@/api/zhihu/history';
 import { followMember, unfollowMember } from '@/api/zhihu/member';
 import { getPin, votePinPoll } from '@/api/zhihu/pin';
 import { BouncyButton } from '@/components/BouncyButton';
 import { LikeButton } from '@/components/LikeButton';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { ShareMenu } from '@/components/ShareMenu';
 import { Text, ThemedIcon, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
@@ -49,6 +50,7 @@ export default function PinDetailScreen() {
   const {
     data: pin,
     isLoading,
+    isError,
     refetch,
   } = useQuery({
     queryKey: ['pin-detail', id],
@@ -76,7 +78,7 @@ export default function PinDetailScreen() {
 
   useEffect(() => {
     if (enableBrowseHistory && pin?.id) {
-      addReadHistory({ content_token: String(pin.id), content_type: 'pin' });
+      recordReadHistory({ content_token: String(pin.id), content_type: 'pin' });
     }
   }, [enableBrowseHistory, pin?.id]);
 
@@ -112,6 +114,13 @@ export default function PinDetailScreen() {
         <Text type="secondary" className="mt-2.5">
           载入想法中...喵
         </Text>
+      </View>
+    );
+
+  if (!pin && isError)
+    return (
+      <View type="default" className="flex-1 justify-center items-center px-6">
+        <QueryErrorView message="想法加载失败" onRetry={() => void refetch()} />
       </View>
     );
 

--- a/app/question/[id]/index.tsx
+++ b/app/question/[id]/index.tsx
@@ -54,7 +54,7 @@ import {
   deleteAnswer,
   type QuestionAnswersResponse,
 } from '@/api/zhihu/answer';
-import { addReadHistory } from '@/api/zhihu/history';
+import { recordReadHistory } from '@/api/zhihu/history';
 import { followMember, unfollowMember } from '@/api/zhihu/member';
 import {
   followQuestion,
@@ -85,6 +85,7 @@ import { useSettingsStore } from '@/store/useSettingsStore';
 import type { ZhihuAuthor } from '@/types/zhihu';
 import { formatDate } from '@/utils/date';
 import { refreshInfiniteQuery } from '@/utils/query';
+import { getZhihuErrorMessage } from '@/utils/zhihuError';
 
 const AnimatedFlashList = Reanimated.createAnimatedComponent(
   FlashList,
@@ -358,6 +359,9 @@ const AnswerItem = forwardRef<AnswerItemHandle, AnswerItemProps>(
       onSuccess: () => {
         Alert.alert('删除成功', '你的回答已删除喵！');
         queryClient.invalidateQueries({ queryKey: ['question-answers'] });
+      },
+      onError: (error) => {
+        Alert.alert('删除失败', getZhihuErrorMessage(error));
       },
     });
 
@@ -871,7 +875,7 @@ export default function QuestionDetail() {
         !recordedAnswerIds.current.has(id)
       ) {
         recordedAnswerIds.current.add(id);
-        addReadHistory({ content_token: id, content_type: 'answer' });
+        recordReadHistory({ content_token: id, content_type: 'answer' });
       }
 
       if (!expanded) {
@@ -1045,7 +1049,7 @@ export default function QuestionDetail() {
 
   React.useEffect(() => {
     if (enableBrowseHistory && question?.id) {
-      addReadHistory({
+      recordReadHistory({
         content_token: String(question.id),
         content_type: 'question',
       });

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -15,6 +15,7 @@ import { getSearchSuggest, searchContent } from '@/api/zhihu';
 import { BouncyButton } from '@/components/BouncyButton';
 import { FeedCard } from '@/components/FeedCard';
 import { BottomSheet } from '@/components/overlays/BottomSheet';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { UserCard } from '@/components/UserCard';
 import { useColorScheme } from '@/components/useColorScheme';
@@ -115,7 +116,7 @@ export default function SearchScreen() {
 
   const { data: suggestions } = useQuery({
     queryKey: ['search-suggest', debouncedQuery],
-    queryFn: () => getSearchSuggest(debouncedQuery),
+    queryFn: ({ signal }) => getSearchSuggest(debouncedQuery, { signal }),
     enabled: debouncedQuery.length > 0 && !isSearching,
   });
 
@@ -125,6 +126,8 @@ export default function SearchScreen() {
     hasNextPage,
     isFetchingNextPage,
     isLoading,
+    isError,
+    refetch,
   } = useInfiniteQuery({
     queryKey: [
       'search-results',
@@ -134,11 +137,12 @@ export default function SearchScreen() {
       sortFilter,
       timeFilter,
     ],
-    queryFn: ({ pageParam = 0 }) =>
+    queryFn: ({ pageParam = 0, signal }) =>
       searchContent(debouncedQuery, pageParam as number, 20, searchType, {
         vertical: searchType === 'general' ? contentFilter : undefined,
         sort: searchType === 'general' ? sortFilter : undefined,
         time_interval: searchType === 'general' ? timeFilter : undefined,
+        signal,
       }),
     enabled: isSearching && debouncedQuery.length > 0,
     initialPageParam: 0,
@@ -664,7 +668,12 @@ export default function SearchScreen() {
             ListFooterComponent: isFetchingNextPage ? (
               <ActivityIndicator style={{ padding: 20 }} color={tintColor} />
             ) : null,
-            ListEmptyComponent: !isLoading ? (
+            ListEmptyComponent: isError ? (
+              <QueryErrorView
+                message="搜索失败"
+                onRetry={() => void refetch()}
+              />
+            ) : !isLoading ? (
               <View className="flex-1 items-center justify-center px-10 py-24">
                 <Ionicons
                   name={emptyStateIcon}

--- a/app/topic/[id].tsx
+++ b/app/topic/[id].tsx
@@ -16,6 +16,7 @@ import {
 } from '@/api/zhihu/topic';
 import { BouncyButton } from '@/components/BouncyButton';
 import { FeedCard } from '@/components/FeedCard';
+import { QueryErrorView } from '@/components/QueryErrorView';
 import { Text, useThemeColor, View } from '@/components/Themed';
 import { useColorScheme } from '@/components/useColorScheme';
 import Colors from '@/constants/Colors';
@@ -37,7 +38,12 @@ export default function TopicDetail() {
     'hot' | 'top-answers' | 'unanswered' | 'structure'
   >('top-answers');
 
-  const { data: topic, isLoading: topicLoading } = useQuery({
+  const {
+    data: topic,
+    isLoading: topicLoading,
+    isError: topicError,
+    refetch: refetchTopic,
+  } = useQuery({
     queryKey: ['topic', id],
     queryFn: () => getTopic(id),
   });
@@ -65,11 +71,13 @@ export default function TopicDetail() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isError: feedError,
     refetch,
     isRefetching,
   } = useZhihuInfiniteQuery({
     queryKey: ['topic-feed', id, activeTab],
-    queryFn: ({ pageParam = 0 }) => getTopicFeed(id, activeTab, pageParam),
+    queryFn: ({ pageParam = 0, signal }) =>
+      getTopicFeed(id, activeTab, pageParam, { signal }),
     initialPageParam: 0,
     enabled: activeTab !== 'structure',
   });
@@ -82,25 +90,38 @@ export default function TopicDetail() {
     );
   }, [queryClient, id, activeTab, refetch]);
 
-  const { data: parentsData, isLoading: parentsLoading } = useQuery({
+  const {
+    data: parentsData,
+    isLoading: parentsLoading,
+    isError: parentsError,
+    refetch: refetchParents,
+  } = useQuery({
     queryKey: ['topic-parents', id],
     queryFn: () => getTopicParents(id),
     enabled: activeTab === 'structure',
   });
 
-  const { data: childrenData, isLoading: childrenLoading } = useQuery({
+  const {
+    data: childrenData,
+    isLoading: childrenLoading,
+    isError: childrenError,
+    refetch: refetchChildren,
+  } = useQuery({
     queryKey: ['topic-children', id],
     queryFn: () => getTopicChildren(id),
     enabled: activeTab === 'structure',
   });
 
-  const { data: bestAnswerersData, isLoading: bestAnswerersLoading } = useQuery(
-    {
-      queryKey: ['topic-best-answerers', id],
-      queryFn: () => getBestAnswerers(id),
-      enabled: activeTab === 'structure',
-    },
-  );
+  const {
+    data: bestAnswerersData,
+    isLoading: bestAnswerersLoading,
+    isError: bestAnswerersError,
+    refetch: refetchBestAnswerers,
+  } = useQuery({
+    queryKey: ['topic-best-answerers', id],
+    queryFn: () => getBestAnswerers(id),
+    enabled: activeTab === 'structure',
+  });
 
   const items = useMemo(() => {
     if (activeTab === 'structure') return [];
@@ -114,6 +135,15 @@ export default function TopicDetail() {
   const renderHeader = useMemo(() => {
     if (!topic && topicLoading)
       return <ActivityIndicator style={{ marginTop: 100 }} />;
+    if (!topic && topicError) {
+      return (
+        <QueryErrorView
+          compact
+          message="话题加载失败"
+          onRetry={() => void refetchTopic()}
+        />
+      );
+    }
     if (!topic) return null;
 
     return (
@@ -207,10 +237,12 @@ export default function TopicDetail() {
   }, [
     topic,
     topicLoading,
+    topicError,
     activeTab,
     tintColor,
     colorScheme,
     followMutation.mutate,
+    refetchTopic,
   ]);
 
   return (
@@ -246,6 +278,12 @@ export default function TopicDetail() {
                 isLoading={
                   parentsLoading || childrenLoading || bestAnswerersLoading
                 }
+                hasError={parentsError || childrenError || bestAnswerersError}
+                onRetry={() => {
+                  void refetchParents();
+                  void refetchChildren();
+                  void refetchBestAnswerers();
+                }}
               />
             )}
           </>
@@ -274,7 +312,13 @@ export default function TopicDetail() {
         ListEmptyComponent={() =>
           !feedLoading &&
           items.length === 0 &&
-          activeTab !== 'structure' && (
+          activeTab !== 'structure' &&
+          (feedError ? (
+            <QueryErrorView
+              message="话题内容加载失败"
+              onRetry={() => void refetch()}
+            />
+          ) : (
             <View className="items-center justify-center mt-20 bg-transparent">
               <Ionicons
                 name="document-text-outline"
@@ -285,7 +329,7 @@ export default function TopicDetail() {
                 暂无内容
               </Text>
             </View>
-          )
+          ))
         }
       />
     </View>
@@ -297,11 +341,15 @@ function TopicStructureView({
   childTopics,
   bestAnswerers,
   isLoading,
+  hasError,
+  onRetry,
 }: {
   parents: any[];
   childTopics: any[];
   bestAnswerers: any[];
   isLoading: boolean;
+  hasError: boolean;
+  onRetry: () => void;
 }) {
   const router = useRouter();
   const primaryColor = useThemeColor({}, 'primary');
@@ -311,6 +359,12 @@ function TopicStructureView({
       <View className="p-10 items-center bg-transparent">
         <ActivityIndicator color={primaryColor} />
       </View>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <QueryErrorView compact message="话题结构加载失败" onRetry={onRetry} />
     );
   }
 

--- a/components/DownvoteButton.tsx
+++ b/components/DownvoteButton.tsx
@@ -10,6 +10,8 @@ import Animated, {
 } from 'react-native-reanimated';
 import { voteContent } from '@/api/zhihu/voters';
 import { colors } from '@/constants/designTokens';
+import { showToast } from '@/utils/toast';
+import { getZhihuErrorMessage } from '@/utils/zhihuError';
 import { BouncyButton } from './BouncyButton';
 import { useThemeColor } from './Themed';
 import { useColorScheme } from './useColorScheme';
@@ -57,7 +59,8 @@ export const DownvoteButton = ({
       await voteContent(id, type, voteType);
       setVoted(nextVoted);
     } catch (err) {
-      console.error('投票失败:', err);
+      console.error('投票失败');
+      showToast(getZhihuErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -1,4 +1,41 @@
 import type { QueryClient, QueryKey } from '@tanstack/react-query';
+import axios from 'axios';
+
+function getResponseStatus(error: unknown): number | undefined {
+  if (!axios.isAxiosError(error)) return undefined;
+  return error.response?.status;
+}
+
+function isVerificationError(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) return false;
+  const data = error.response?.data;
+  if (!data || typeof data !== 'object' || !('error' in data)) return false;
+  const detail = data.error;
+  return (
+    typeof detail === 'object' &&
+    detail !== null &&
+    'code' in detail &&
+    detail.code === 40352
+  );
+}
+
+/** Retry only transient request failures; client errors need user/action changes. */
+export function shouldRetryQuery(
+  failureCount: number,
+  error: unknown,
+): boolean {
+  if (axios.isCancel(error)) return false;
+  if (isVerificationError(error)) return false;
+
+  const status = getResponseStatus(error);
+  if (status !== undefined) {
+    return status === 408 || status === 429 || status >= 500
+      ? failureCount < 2
+      : false;
+  }
+
+  return axios.isAxiosError(error) && failureCount < 2;
+}
 
 /**
  * Reset one TanStack infinite query to its initial state and refetch active observers.

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -125,8 +125,8 @@ export function parseZhihuUrl(url: string | null): string | null {
   try {
     const path = extractPath(url);
     return path ? normalizeSupportedPath(path) : null;
-  } catch (err) {
-    console.error('[URL Parser] Failed to parse:', url, err);
+  } catch {
+    console.error('[URL Parser] Failed to parse URL');
     return null;
   }
 }

--- a/utils/zhihuError.ts
+++ b/utils/zhihuError.ts
@@ -4,6 +4,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export function getZhihuErrorMessage(error: unknown): string {
   if (isRecord(error) && isRecord(error.response)) {
+    const status = error.response.status;
     const data = error.response.data;
     if (isRecord(data) && isRecord(data.error)) {
       const message = data.error.message;
@@ -13,6 +14,26 @@ export function getZhihuErrorMessage(error: unknown): string {
       const message = data.message;
       if (typeof message === 'string' && message) return message;
     }
+    if (typeof status === 'number') {
+      if (status === 400) return '请求参数无效，请检查后重试';
+      if (status === 401) return '登录状态已失效，请重新登录';
+      if (status === 403) return '当前账号没有执行此操作的权限';
+      if (status === 404) return '请求的内容不存在或已被删除';
+      if (status === 408) return '请求超时，请稍后重试';
+      if (status === 429) return '操作太频繁，请稍后重试';
+      if (status >= 500) return '知乎服务暂时不可用，请稍后重试';
+    }
+  }
+
+  if (isRecord(error)) {
+    const code = error.code;
+    if (code === 'ECONNABORTED' || code === 'ETIMEDOUT') {
+      return '请求超时，请检查网络后重试';
+    }
+    if (code === 'ERR_NETWORK') return '网络连接失败，请检查网络后重试';
+
+    const message = error.message;
+    if (typeof message === 'string' && message) return message;
   }
 
   if (error instanceof Error && error.message) return error.message;


### PR DESCRIPTION
## Summary

- 按 HTTP status 统一处理 API 错误：4xx 不重试，408/429/5xx 仅有限重试，取消请求不重试
- 修复 Feed 吞掉异常、浏览历史未处理 Promise，以及多个页面将请求失败显示为空列表的问题
- 增加分页请求取消、401 会话刷新/失效处理和关键 mutation 失败反馈
- 限制图片上传轮询重试范围，并脱敏登录与 URL 解析日志
- 游客态不再请求需要登录的浏览历史接口

## Validation

- npm run typecheck
- npm test
- npm run analyze:rich-content
- npm run lint（0 error，120 个存量 warning）
- git diff --check